### PR TITLE
Add CRDs for KubernetesCluster, KubernetesProvider, KubevirtConfig, Machine, MachineClass, MachineProvider, NetworkConfiguration, NetworkNamespace, ProxmoxConfig, and Vitistack

### DIFF
--- a/docs/images/operator-layers.svg
+++ b/docs/images/operator-layers.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 620" font-family="'Segoe UI', system-ui, -apple-system, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 690" font-family="'Segoe UI', system-ui, -apple-system, sans-serif">
   <defs>
     <filter id="shadow" x="-4%" y="-4%" width="108%" height="112%">
       <feDropShadow dx="0" dy="2" stdDeviation="4" flood-opacity="0.15"/>
@@ -22,7 +22,7 @@
   </defs>
 
   <!-- Background -->
-  <rect width="900" height="620" rx="16" fill="#f8fafc"/>
+  <rect width="900" height="690" rx="16" fill="#f8fafc"/>
 
   <!-- Title -->
   <text x="450" y="40" text-anchor="middle" font-size="22" font-weight="700" fill="#1e293b">Vitistack Cluster Lifecycle</text>
@@ -32,7 +32,7 @@
   <rect x="40" y="60" width="6" height="110" rx="3" fill="url(#grad-purple)"/>
 
   <!-- Cluster icon -->
-  <g transform="translate(70, 85)">
+  <g transform="translate(70, 78)">
     <circle cx="20" cy="14" r="6" fill="none" stroke="#7c3aed" stroke-width="2"/>
     <circle cx="8" cy="30" r="6" fill="none" stroke="#7c3aed" stroke-width="2"/>
     <circle cx="32" cy="30" r="6" fill="none" stroke="#7c3aed" stroke-width="2"/>
@@ -41,26 +41,30 @@
     <line x1="14" y1="30" x2="26" y2="30" stroke="#7c3aed" stroke-width="1.5"/>
   </g>
 
-  <text x="120" y="90" font-size="16" font-weight="700" fill="#7c3aed">Cluster Provisioning</text>
-  <text x="120" y="110" font-size="12" fill="#64748b">Orchestrates Kubernetes cluster creation from Machine resources</text>
+  <text x="120" y="86" font-size="16" font-weight="700" fill="#7c3aed">Cluster Provisioning</text>
+  <text x="120" y="104" font-size="12" fill="#64748b">Orchestrates Kubernetes cluster creation from Machine resources</text>
 
-  <!-- Operator pills -->
-  <rect x="120" y="125" width="160" height="32" rx="16" fill="#7c3aed" opacity="0.9"/>
-  <text x="200" y="146" text-anchor="middle" font-size="13" font-weight="600" fill="white">talos-operator</text>
+  <!-- Operator pill -->
+  <rect x="120" y="118" width="180" height="30" rx="15" fill="#7c3aed" opacity="0.9"/>
+  <text x="210" y="138" text-anchor="middle" font-size="13" font-weight="600" fill="white">talos-operator</text>
+
+  <!-- CRD pill -->
+  <rect x="620" y="118" width="180" height="30" rx="15" fill="#7c3aed" opacity="0.15"/>
+  <text x="710" y="138" text-anchor="middle" font-size="13" fill="#7c3aed">KubernetesCluster</text>
 
   <!-- Arrow up -->
   <g transform="translate(440, 172)">
     <line x1="0" y1="4" x2="0" y2="26" stroke="#94a3b8" stroke-width="2" stroke-dasharray="4,3"/>
     <polygon points="-5,8 0,0 5,8" fill="#94a3b8"/>
   </g>
-  <text x="460" y="188" font-size="11" fill="#94a3b8" font-style="italic">machines running</text>
+  <text x="460" y="190" font-size="11" fill="#94a3b8" font-style="italic">machines running</text>
 
   <!-- === Layer 3: Machine Provisioning === -->
-  <rect x="40" y="200" width="820" height="110" rx="12" fill="url(#grad-orange)" opacity="0.12" filter="url(#shadow)"/>
-  <rect x="40" y="200" width="6" height="110" rx="3" fill="url(#grad-orange)"/>
+  <rect x="40" y="205" width="820" height="110" rx="12" fill="url(#grad-orange)" opacity="0.12" filter="url(#shadow)"/>
+  <rect x="40" y="205" width="6" height="110" rx="3" fill="url(#grad-orange)"/>
 
   <!-- Server icon -->
-  <g transform="translate(70, 225)">
+  <g transform="translate(70, 223)">
     <rect x="2" y="2" width="36" height="14" rx="3" fill="none" stroke="#ea580c" stroke-width="2"/>
     <rect x="2" y="22" width="36" height="14" rx="3" fill="none" stroke="#ea580c" stroke-width="2"/>
     <circle cx="30" cy="9" r="2.5" fill="#ea580c"/>
@@ -69,54 +73,64 @@
     <line x1="8" y1="29" x2="22" y2="29" stroke="#ea580c" stroke-width="1.5"/>
   </g>
 
-  <text x="120" y="230" font-size="16" font-weight="700" fill="#ea580c">Machine Provisioning</text>
-  <text x="120" y="250" font-size="12" fill="#64748b">Creates and manages virtual machines on the hypervisor</text>
+  <text x="120" y="231" font-size="16" font-weight="700" fill="#ea580c">Machine Provisioning</text>
+  <text x="120" y="249" font-size="12" fill="#64748b">Creates and manages virtual machines on the hypervisor</text>
 
-  <rect x="120" y="265" width="170" height="32" rx="16" fill="#ea580c" opacity="0.9"/>
-  <text x="205" y="286" text-anchor="middle" font-size="13" font-weight="600" fill="white">kubevirt-operator</text>
+  <rect x="120" y="263" width="180" height="30" rx="15" fill="#ea580c" opacity="0.9"/>
+  <text x="210" y="283" text-anchor="middle" font-size="13" font-weight="600" fill="white">kubevirt-operator</text>
 
-  <rect x="310" y="265" width="170" height="32" rx="16" fill="#ea580c" opacity="0.9"/>
-  <text x="395" y="286" text-anchor="middle" font-size="13" font-weight="600" fill="white">proxmox-operator</text>
+  <rect x="315" y="263" width="180" height="30" rx="15" fill="#ea580c" opacity="0.9"/>
+  <text x="405" y="283" text-anchor="middle" font-size="13" font-weight="600" fill="white">proxmox-operator</text>
+
+  <!-- CRD pill -->
+  <rect x="620" y="263" width="180" height="30" rx="15" fill="#ea580c" opacity="0.15"/>
+  <text x="710" y="283" text-anchor="middle" font-size="13" fill="#ea580c">Machine</text>
 
   <!-- Arrow up -->
-  <g transform="translate(440, 312)">
+  <g transform="translate(440, 317)">
     <line x1="0" y1="4" x2="0" y2="26" stroke="#94a3b8" stroke-width="2" stroke-dasharray="4,3"/>
     <polygon points="-5,8 0,0 5,8" fill="#94a3b8"/>
   </g>
-  <text x="460" y="328" font-size="11" fill="#94a3b8" font-style="italic">IP assigned</text>
+  <text x="460" y="335" font-size="11" fill="#94a3b8" font-style="italic">IP assigned</text>
 
   <!-- === Layer 2: IP Allocation === -->
-  <rect x="40" y="340" width="820" height="110" rx="12" fill="url(#grad-green)" opacity="0.12" filter="url(#shadow)"/>
-  <rect x="40" y="340" width="6" height="110" rx="3" fill="url(#grad-green)"/>
+  <rect x="40" y="350" width="820" height="110" rx="12" fill="url(#grad-green)" opacity="0.12" filter="url(#shadow)"/>
+  <rect x="40" y="350" width="6" height="110" rx="3" fill="url(#grad-green)"/>
 
   <!-- IP icon -->
-  <g transform="translate(70, 362)">
+  <g transform="translate(70, 368)">
     <rect x="2" y="5" width="36" height="28" rx="4" fill="none" stroke="#059669" stroke-width="2"/>
     <text x="20" y="25" text-anchor="middle" font-size="14" font-weight="700" fill="#059669">IP</text>
   </g>
 
-  <text x="120" y="370" font-size="16" font-weight="700" fill="#059669">IP Allocation</text>
-  <text x="120" y="390" font-size="12" fill="#64748b">Assigns IP addresses to machines via static pools or DHCP</text>
+  <text x="120" y="376" font-size="16" font-weight="700" fill="#059669">IP Allocation</text>
+  <text x="120" y="394" font-size="12" fill="#64748b">Assigns IP addresses to machines via static pools or DHCP</text>
 
-  <rect x="120" y="405" width="170" height="32" rx="16" fill="#059669" opacity="0.9"/>
-  <text x="205" y="426" text-anchor="middle" font-size="13" font-weight="600" fill="white">static-ip-operator</text>
+  <rect x="120" y="408" width="180" height="30" rx="15" fill="#059669" opacity="0.9"/>
+  <text x="210" y="428" text-anchor="middle" font-size="13" font-weight="600" fill="white">static-ip-operator</text>
 
-  <rect x="310" y="405" width="150" height="32" rx="16" fill="#059669" opacity="0.9"/>
-  <text x="385" y="426" text-anchor="middle" font-size="13" font-weight="600" fill="white">kea-operator</text>
+  <rect x="315" y="408" width="180" height="30" rx="15" fill="#059669" opacity="0.9"/>
+  <text x="405" y="428" text-anchor="middle" font-size="13" font-weight="600" fill="white">kea-operator</text>
+
+  <!-- CRD pills -->
+  <rect x="620" y="372" width="180" height="30" rx="15" fill="#059669" opacity="0.15"/>
+  <text x="710" y="392" text-anchor="middle" font-size="13" fill="#059669">IPAllocation</text>
+  <rect x="620" y="408" width="180" height="30" rx="15" fill="#059669" opacity="0.15"/>
+  <text x="710" y="428" text-anchor="middle" font-size="13" fill="#059669">NetworkConfiguration</text>
 
   <!-- Arrow up -->
-  <g transform="translate(440, 452)">
+  <g transform="translate(440, 462)">
     <line x1="0" y1="4" x2="0" y2="26" stroke="#94a3b8" stroke-width="2" stroke-dasharray="4,3"/>
     <polygon points="-5,8 0,0 5,8" fill="#94a3b8"/>
   </g>
-  <text x="460" y="468" font-size="11" fill="#94a3b8" font-style="italic">network ready</text>
+  <text x="460" y="480" font-size="11" fill="#94a3b8" font-style="italic">network ready</text>
 
   <!-- === Layer 1: Network Provisioning (bottom) === -->
-  <rect x="40" y="480" width="820" height="120" rx="12" fill="url(#grad-blue)" opacity="0.12" filter="url(#shadow)"/>
-  <rect x="40" y="480" width="6" height="120" rx="3" fill="url(#grad-blue)"/>
+  <rect x="40" y="495" width="820" height="110" rx="12" fill="url(#grad-blue)" opacity="0.12" filter="url(#shadow)"/>
+  <rect x="40" y="495" width="6" height="110" rx="3" fill="url(#grad-blue)"/>
 
   <!-- Network icon -->
-  <g transform="translate(70, 502)">
+  <g transform="translate(70, 513)">
     <circle cx="20" cy="8" r="5" fill="none" stroke="#0284c7" stroke-width="2"/>
     <circle cx="6" cy="30" r="5" fill="none" stroke="#0284c7" stroke-width="2"/>
     <circle cx="34" cy="30" r="5" fill="none" stroke="#0284c7" stroke-width="2"/>
@@ -124,12 +138,29 @@
     <line x1="24" y1="12" x2="31" y2="26" stroke="#0284c7" stroke-width="1.5"/>
   </g>
 
-  <text x="120" y="510" font-size="16" font-weight="700" fill="#0284c7">Network Provisioning</text>
-  <text x="120" y="530" font-size="12" fill="#64748b">Provisions network segments with IP prefixes and VLANs</text>
+  <text x="120" y="521" font-size="16" font-weight="700" fill="#0284c7">Network Provisioning</text>
+  <text x="120" y="539" font-size="12" fill="#64748b">Provisions network segments with IP prefixes and VLANs</text>
 
-  <rect x="120" y="548" width="155" height="32" rx="16" fill="#0284c7" opacity="0.9"/>
-  <text x="197" y="569" text-anchor="middle" font-size="13" font-weight="600" fill="white">nms-operator</text>
+  <rect x="120" y="555" width="180" height="30" rx="15" fill="#0284c7" opacity="0.9"/>
+  <text x="210" y="575" text-anchor="middle" font-size="13" font-weight="600" fill="white">nms-operator</text>
 
-  <rect x="295" y="548" width="290" height="32" rx="16" fill="#0284c7" opacity="0.9"/>
-  <text x="440" y="569" text-anchor="middle" font-size="13" font-weight="600" fill="white">manual-ip-provisioning-operator</text>
+  <rect x="315" y="555" width="280" height="30" rx="15" fill="#0284c7" opacity="0.9"/>
+  <text x="455" y="575" text-anchor="middle" font-size="13" font-weight="600" fill="white">manual-ip-provisioning-operator</text>
+
+  <!-- CRD pill -->
+  <rect x="620" y="555" width="180" height="30" rx="15" fill="#0284c7" opacity="0.15"/>
+  <text x="710" y="575" text-anchor="middle" font-size="13" fill="#0284c7">NetworkNamespace</text>
+
+  <!-- Legend -->
+  <g transform="translate(220, 618)">
+    <rect x="0" y="0" width="460" height="52" rx="8" fill="none" stroke="#cbd5e1" stroke-width="1"/>
+    <text x="16" y="32" font-size="11" font-weight="600" fill="#94a3b8">LEGEND</text>
+    <rect x="80" y="13" width="100" height="26" rx="13" fill="#64748b" opacity="0.9"/>
+    <text x="130" y="31" text-anchor="middle" font-size="12" font-weight="600" fill="white">Operator</text>
+    <rect x="200" y="13" width="100" height="26" rx="13" fill="#64748b" opacity="0.15"/>
+    <text x="250" y="31" text-anchor="middle" font-size="12" fill="#64748b">CRD</text>
+    <line x1="320" y1="26" x2="350" y2="26" stroke="#94a3b8" stroke-width="2" stroke-dasharray="4,3"/>
+    <polygon points="345,22 353,26 345,30" fill="#94a3b8"/>
+    <text x="362" y="31" font-size="12" fill="#94a3b8">Lifecycle flow</text>
+  </g>
 </svg>

--- a/docs/images/operator-layers.svg
+++ b/docs/images/operator-layers.svg
@@ -1,0 +1,135 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 620" font-family="'Segoe UI', system-ui, -apple-system, sans-serif">
+  <defs>
+    <filter id="shadow" x="-4%" y="-4%" width="108%" height="112%">
+      <feDropShadow dx="0" dy="2" stdDeviation="4" flood-opacity="0.15"/>
+    </filter>
+    <linearGradient id="grad-purple" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#7c3aed"/>
+      <stop offset="100%" stop-color="#a78bfa"/>
+    </linearGradient>
+    <linearGradient id="grad-orange" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#ea580c"/>
+      <stop offset="100%" stop-color="#fb923c"/>
+    </linearGradient>
+    <linearGradient id="grad-green" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#059669"/>
+      <stop offset="100%" stop-color="#34d399"/>
+    </linearGradient>
+    <linearGradient id="grad-blue" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#0284c7"/>
+      <stop offset="100%" stop-color="#38bdf8"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="900" height="620" rx="16" fill="#f8fafc"/>
+
+  <!-- Title -->
+  <text x="450" y="40" text-anchor="middle" font-size="22" font-weight="700" fill="#1e293b">Viti Stack Operator Lifecycle</text>
+
+  <!-- === Layer 4: Cluster Provisioning (top) === -->
+  <rect x="40" y="60" width="820" height="110" rx="12" fill="url(#grad-purple)" opacity="0.12" filter="url(#shadow)"/>
+  <rect x="40" y="60" width="6" height="110" rx="3" fill="url(#grad-purple)"/>
+
+  <!-- Cluster icon -->
+  <g transform="translate(70, 85)">
+    <circle cx="20" cy="14" r="6" fill="none" stroke="#7c3aed" stroke-width="2"/>
+    <circle cx="8" cy="30" r="6" fill="none" stroke="#7c3aed" stroke-width="2"/>
+    <circle cx="32" cy="30" r="6" fill="none" stroke="#7c3aed" stroke-width="2"/>
+    <line x1="16" y1="18" x2="11" y2="25" stroke="#7c3aed" stroke-width="1.5"/>
+    <line x1="24" y1="18" x2="29" y2="25" stroke="#7c3aed" stroke-width="1.5"/>
+    <line x1="14" y1="30" x2="26" y2="30" stroke="#7c3aed" stroke-width="1.5"/>
+  </g>
+
+  <text x="120" y="90" font-size="16" font-weight="700" fill="#7c3aed">Cluster Provisioning</text>
+  <text x="120" y="110" font-size="12" fill="#64748b">Orchestrates Kubernetes cluster creation from Machine resources</text>
+
+  <!-- Operator pills -->
+  <rect x="120" y="125" width="160" height="32" rx="16" fill="#7c3aed" opacity="0.9"/>
+  <text x="200" y="146" text-anchor="middle" font-size="13" font-weight="600" fill="white">talos-operator</text>
+
+  <!-- Arrow up -->
+  <g transform="translate(440, 172)">
+    <line x1="0" y1="4" x2="0" y2="26" stroke="#94a3b8" stroke-width="2" stroke-dasharray="4,3"/>
+    <polygon points="-5,8 0,0 5,8" fill="#94a3b8"/>
+  </g>
+  <text x="460" y="188" font-size="11" fill="#94a3b8" font-style="italic">machines running</text>
+
+  <!-- === Layer 3: Machine Provisioning === -->
+  <rect x="40" y="200" width="820" height="110" rx="12" fill="url(#grad-orange)" opacity="0.12" filter="url(#shadow)"/>
+  <rect x="40" y="200" width="6" height="110" rx="3" fill="url(#grad-orange)"/>
+
+  <!-- Server icon -->
+  <g transform="translate(70, 225)">
+    <rect x="2" y="2" width="36" height="14" rx="3" fill="none" stroke="#ea580c" stroke-width="2"/>
+    <rect x="2" y="22" width="36" height="14" rx="3" fill="none" stroke="#ea580c" stroke-width="2"/>
+    <circle cx="30" cy="9" r="2.5" fill="#ea580c"/>
+    <circle cx="30" cy="29" r="2.5" fill="#ea580c"/>
+    <line x1="8" y1="9" x2="22" y2="9" stroke="#ea580c" stroke-width="1.5"/>
+    <line x1="8" y1="29" x2="22" y2="29" stroke="#ea580c" stroke-width="1.5"/>
+  </g>
+
+  <text x="120" y="230" font-size="16" font-weight="700" fill="#ea580c">Machine Provisioning</text>
+  <text x="120" y="250" font-size="12" fill="#64748b">Creates and manages virtual machines on the hypervisor</text>
+
+  <rect x="120" y="265" width="170" height="32" rx="16" fill="#ea580c" opacity="0.9"/>
+  <text x="205" y="286" text-anchor="middle" font-size="13" font-weight="600" fill="white">kubevirt-operator</text>
+
+  <rect x="310" y="265" width="170" height="32" rx="16" fill="#ea580c" opacity="0.9"/>
+  <text x="395" y="286" text-anchor="middle" font-size="13" font-weight="600" fill="white">proxmox-operator</text>
+
+  <!-- Arrow up -->
+  <g transform="translate(440, 312)">
+    <line x1="0" y1="4" x2="0" y2="26" stroke="#94a3b8" stroke-width="2" stroke-dasharray="4,3"/>
+    <polygon points="-5,8 0,0 5,8" fill="#94a3b8"/>
+  </g>
+  <text x="460" y="328" font-size="11" fill="#94a3b8" font-style="italic">IP assigned</text>
+
+  <!-- === Layer 2: IP Allocation === -->
+  <rect x="40" y="340" width="820" height="110" rx="12" fill="url(#grad-green)" opacity="0.12" filter="url(#shadow)"/>
+  <rect x="40" y="340" width="6" height="110" rx="3" fill="url(#grad-green)"/>
+
+  <!-- IP icon -->
+  <g transform="translate(70, 362)">
+    <rect x="2" y="5" width="36" height="28" rx="4" fill="none" stroke="#059669" stroke-width="2"/>
+    <text x="20" y="25" text-anchor="middle" font-size="14" font-weight="700" fill="#059669">IP</text>
+  </g>
+
+  <text x="120" y="370" font-size="16" font-weight="700" fill="#059669">IP Allocation</text>
+  <text x="120" y="390" font-size="12" fill="#64748b">Assigns IP addresses to machines via static pools or DHCP</text>
+
+  <rect x="120" y="405" width="170" height="32" rx="16" fill="#059669" opacity="0.9"/>
+  <text x="205" y="426" text-anchor="middle" font-size="13" font-weight="600" fill="white">static-ip-operator</text>
+
+  <rect x="310" y="405" width="150" height="32" rx="16" fill="#059669" opacity="0.9"/>
+  <text x="385" y="426" text-anchor="middle" font-size="13" font-weight="600" fill="white">kea-operator</text>
+
+  <!-- Arrow up -->
+  <g transform="translate(440, 452)">
+    <line x1="0" y1="4" x2="0" y2="26" stroke="#94a3b8" stroke-width="2" stroke-dasharray="4,3"/>
+    <polygon points="-5,8 0,0 5,8" fill="#94a3b8"/>
+  </g>
+  <text x="460" y="468" font-size="11" fill="#94a3b8" font-style="italic">network ready</text>
+
+  <!-- === Layer 1: Network Provisioning (bottom) === -->
+  <rect x="40" y="480" width="820" height="120" rx="12" fill="url(#grad-blue)" opacity="0.12" filter="url(#shadow)"/>
+  <rect x="40" y="480" width="6" height="120" rx="3" fill="url(#grad-blue)"/>
+
+  <!-- Network icon -->
+  <g transform="translate(70, 502)">
+    <circle cx="20" cy="8" r="5" fill="none" stroke="#0284c7" stroke-width="2"/>
+    <circle cx="6" cy="30" r="5" fill="none" stroke="#0284c7" stroke-width="2"/>
+    <circle cx="34" cy="30" r="5" fill="none" stroke="#0284c7" stroke-width="2"/>
+    <line x1="16" y1="12" x2="9" y2="26" stroke="#0284c7" stroke-width="1.5"/>
+    <line x1="24" y1="12" x2="31" y2="26" stroke="#0284c7" stroke-width="1.5"/>
+  </g>
+
+  <text x="120" y="510" font-size="16" font-weight="700" fill="#0284c7">Network Provisioning</text>
+  <text x="120" y="530" font-size="12" fill="#64748b">Provisions network segments with IP prefixes and VLANs</text>
+
+  <rect x="120" y="548" width="155" height="32" rx="16" fill="#0284c7" opacity="0.9"/>
+  <text x="197" y="569" text-anchor="middle" font-size="13" font-weight="600" fill="white">nms-operator</text>
+
+  <rect x="295" y="548" width="290" height="32" rx="16" fill="#0284c7" opacity="0.9"/>
+  <text x="440" y="569" text-anchor="middle" font-size="13" font-weight="600" fill="white">manual-ip-provisioning-operator</text>
+</svg>

--- a/docs/images/operator-layers.svg
+++ b/docs/images/operator-layers.svg
@@ -25,7 +25,7 @@
   <rect width="900" height="620" rx="16" fill="#f8fafc"/>
 
   <!-- Title -->
-  <text x="450" y="40" text-anchor="middle" font-size="22" font-weight="700" fill="#1e293b">Viti Stack Operator Lifecycle</text>
+  <text x="450" y="40" text-anchor="middle" font-size="22" font-weight="700" fill="#1e293b">Vitistack Cluster Lifecycle</text>
 
   <!-- === Layer 4: Cluster Provisioning (top) === -->
   <rect x="40" y="60" width="820" height="110" rx="12" fill="url(#grad-purple)" opacity="0.12" filter="url(#shadow)"/>

--- a/docs/images/operator-layers.svg
+++ b/docs/images/operator-layers.svg
@@ -27,12 +27,45 @@
   <!-- Title -->
   <text x="450" y="40" text-anchor="middle" font-size="22" font-weight="700" fill="#1e293b">Vitistack Cluster Lifecycle</text>
 
-  <!-- === Layer 4: Cluster Provisioning (top) === -->
-  <rect x="40" y="60" width="820" height="110" rx="12" fill="url(#grad-purple)" opacity="0.12" filter="url(#shadow)"/>
-  <rect x="40" y="60" width="6" height="110" rx="3" fill="url(#grad-purple)"/>
+  <!-- === Layer 1: Network Provisioning (top) === -->
+  <rect x="40" y="60" width="820" height="110" rx="12" fill="url(#grad-blue)" opacity="0.12" filter="url(#shadow)"/>
+  <rect x="40" y="60" width="6" height="110" rx="3" fill="url(#grad-blue)"/>
+
+  <!-- Network icon -->
+  <g transform="translate(70, 78)">
+    <circle cx="20" cy="8" r="5" fill="none" stroke="#0284c7" stroke-width="2"/>
+    <circle cx="6" cy="30" r="5" fill="none" stroke="#0284c7" stroke-width="2"/>
+    <circle cx="34" cy="30" r="5" fill="none" stroke="#0284c7" stroke-width="2"/>
+    <line x1="16" y1="12" x2="9" y2="26" stroke="#0284c7" stroke-width="1.5"/>
+    <line x1="24" y1="12" x2="31" y2="26" stroke="#0284c7" stroke-width="1.5"/>
+  </g>
+
+  <text x="120" y="86" font-size="16" font-weight="700" fill="#0284c7">Network Provisioning</text>
+  <text x="120" y="104" font-size="12" fill="#64748b">Provisions network segments with IP prefixes and VLANs</text>
+
+  <rect x="120" y="118" width="180" height="30" rx="15" fill="#0284c7" opacity="0.9"/>
+  <text x="210" y="138" text-anchor="middle" font-size="13" font-weight="600" fill="white">nms-operator</text>
+
+  <rect x="315" y="118" width="280" height="30" rx="15" fill="#0284c7" opacity="0.9"/>
+  <text x="455" y="138" text-anchor="middle" font-size="13" font-weight="600" fill="white">manual-ip-provisioning-operator</text>
+
+  <!-- CRD pill -->
+  <rect x="620" y="118" width="180" height="30" rx="15" fill="#0284c7" opacity="0.15"/>
+  <text x="710" y="138" text-anchor="middle" font-size="13" fill="#0284c7">NetworkNamespace</text>
+
+  <!-- Arrow down -->
+  <g transform="translate(440, 172)">
+    <line x1="0" y1="0" x2="0" y2="22" stroke="#94a3b8" stroke-width="2" stroke-dasharray="4,3"/>
+    <polygon points="-5,18 0,26 5,18" fill="#94a3b8"/>
+  </g>
+  <text x="460" y="190" font-size="11" fill="#94a3b8" font-style="italic">network ready</text>
+
+  <!-- === Layer 2: Cluster Provisioning === -->
+  <rect x="40" y="205" width="820" height="110" rx="12" fill="url(#grad-purple)" opacity="0.12" filter="url(#shadow)"/>
+  <rect x="40" y="205" width="6" height="110" rx="3" fill="url(#grad-purple)"/>
 
   <!-- Cluster icon -->
-  <g transform="translate(70, 78)">
+  <g transform="translate(70, 223)">
     <circle cx="20" cy="14" r="6" fill="none" stroke="#7c3aed" stroke-width="2"/>
     <circle cx="8" cy="30" r="6" fill="none" stroke="#7c3aed" stroke-width="2"/>
     <circle cx="32" cy="30" r="6" fill="none" stroke="#7c3aed" stroke-width="2"/>
@@ -41,30 +74,30 @@
     <line x1="14" y1="30" x2="26" y2="30" stroke="#7c3aed" stroke-width="1.5"/>
   </g>
 
-  <text x="120" y="86" font-size="16" font-weight="700" fill="#7c3aed">Cluster Provisioning</text>
-  <text x="120" y="104" font-size="12" fill="#64748b">Orchestrates Kubernetes cluster creation from Machine resources</text>
+  <text x="120" y="231" font-size="16" font-weight="700" fill="#7c3aed">Cluster Provisioning</text>
+  <text x="120" y="249" font-size="12" fill="#64748b">Orchestrates Kubernetes cluster creation from Machine resources</text>
 
   <!-- Operator pill -->
-  <rect x="120" y="118" width="180" height="30" rx="15" fill="#7c3aed" opacity="0.9"/>
-  <text x="210" y="138" text-anchor="middle" font-size="13" font-weight="600" fill="white">talos-operator</text>
+  <rect x="120" y="263" width="180" height="30" rx="15" fill="#7c3aed" opacity="0.9"/>
+  <text x="210" y="283" text-anchor="middle" font-size="13" font-weight="600" fill="white">talos-operator</text>
 
   <!-- CRD pill -->
-  <rect x="620" y="118" width="180" height="30" rx="15" fill="#7c3aed" opacity="0.15"/>
-  <text x="710" y="138" text-anchor="middle" font-size="13" fill="#7c3aed">KubernetesCluster</text>
+  <rect x="620" y="263" width="180" height="30" rx="15" fill="#7c3aed" opacity="0.15"/>
+  <text x="710" y="283" text-anchor="middle" font-size="13" fill="#7c3aed">KubernetesCluster</text>
 
-  <!-- Arrow up -->
-  <g transform="translate(440, 172)">
-    <line x1="0" y1="4" x2="0" y2="26" stroke="#94a3b8" stroke-width="2" stroke-dasharray="4,3"/>
-    <polygon points="-5,8 0,0 5,8" fill="#94a3b8"/>
+  <!-- Arrow down -->
+  <g transform="translate(440, 317)">
+    <line x1="0" y1="0" x2="0" y2="22" stroke="#94a3b8" stroke-width="2" stroke-dasharray="4,3"/>
+    <polygon points="-5,18 0,26 5,18" fill="#94a3b8"/>
   </g>
-  <text x="460" y="190" font-size="11" fill="#94a3b8" font-style="italic">machines running</text>
+  <text x="460" y="335" font-size="11" fill="#94a3b8" font-style="italic">machines running</text>
 
   <!-- === Layer 3: Machine Provisioning === -->
-  <rect x="40" y="205" width="820" height="110" rx="12" fill="url(#grad-orange)" opacity="0.12" filter="url(#shadow)"/>
-  <rect x="40" y="205" width="6" height="110" rx="3" fill="url(#grad-orange)"/>
+  <rect x="40" y="350" width="820" height="110" rx="12" fill="url(#grad-orange)" opacity="0.12" filter="url(#shadow)"/>
+  <rect x="40" y="350" width="6" height="110" rx="3" fill="url(#grad-orange)"/>
 
   <!-- Server icon -->
-  <g transform="translate(70, 223)">
+  <g transform="translate(70, 368)">
     <rect x="2" y="2" width="36" height="14" rx="3" fill="none" stroke="#ea580c" stroke-width="2"/>
     <rect x="2" y="22" width="36" height="14" rx="3" fill="none" stroke="#ea580c" stroke-width="2"/>
     <circle cx="30" cy="9" r="2.5" fill="#ea580c"/>
@@ -73,83 +106,50 @@
     <line x1="8" y1="29" x2="22" y2="29" stroke="#ea580c" stroke-width="1.5"/>
   </g>
 
-  <text x="120" y="231" font-size="16" font-weight="700" fill="#ea580c">Machine Provisioning</text>
-  <text x="120" y="249" font-size="12" fill="#64748b">Creates and manages virtual machines on the hypervisor</text>
+  <text x="120" y="376" font-size="16" font-weight="700" fill="#ea580c">Machine Provisioning</text>
+  <text x="120" y="394" font-size="12" fill="#64748b">Creates and manages virtual machines on the hypervisor</text>
 
-  <rect x="120" y="263" width="180" height="30" rx="15" fill="#ea580c" opacity="0.9"/>
-  <text x="210" y="283" text-anchor="middle" font-size="13" font-weight="600" fill="white">kubevirt-operator</text>
+  <rect x="120" y="408" width="180" height="30" rx="15" fill="#ea580c" opacity="0.9"/>
+  <text x="210" y="428" text-anchor="middle" font-size="13" font-weight="600" fill="white">kubevirt-operator</text>
 
-  <rect x="315" y="263" width="180" height="30" rx="15" fill="#ea580c" opacity="0.9"/>
-  <text x="405" y="283" text-anchor="middle" font-size="13" font-weight="600" fill="white">proxmox-operator</text>
+  <rect x="315" y="408" width="180" height="30" rx="15" fill="#ea580c" opacity="0.9"/>
+  <text x="405" y="428" text-anchor="middle" font-size="13" font-weight="600" fill="white">proxmox-operator</text>
 
   <!-- CRD pill -->
-  <rect x="620" y="263" width="180" height="30" rx="15" fill="#ea580c" opacity="0.15"/>
-  <text x="710" y="283" text-anchor="middle" font-size="13" fill="#ea580c">Machine</text>
+  <rect x="620" y="408" width="180" height="30" rx="15" fill="#ea580c" opacity="0.15"/>
+  <text x="710" y="428" text-anchor="middle" font-size="13" fill="#ea580c">Machine</text>
 
-  <!-- Arrow up -->
-  <g transform="translate(440, 317)">
-    <line x1="0" y1="4" x2="0" y2="26" stroke="#94a3b8" stroke-width="2" stroke-dasharray="4,3"/>
-    <polygon points="-5,8 0,0 5,8" fill="#94a3b8"/>
+  <!-- Arrow down -->
+  <g transform="translate(440, 462)">
+    <line x1="0" y1="0" x2="0" y2="22" stroke="#94a3b8" stroke-width="2" stroke-dasharray="4,3"/>
+    <polygon points="-5,18 0,26 5,18" fill="#94a3b8"/>
   </g>
-  <text x="460" y="335" font-size="11" fill="#94a3b8" font-style="italic">IP assigned</text>
+  <text x="460" y="480" font-size="11" fill="#94a3b8" font-style="italic">IP assigned</text>
 
-  <!-- === Layer 2: IP Allocation === -->
-  <rect x="40" y="350" width="820" height="110" rx="12" fill="url(#grad-green)" opacity="0.12" filter="url(#shadow)"/>
-  <rect x="40" y="350" width="6" height="110" rx="3" fill="url(#grad-green)"/>
+  <!-- === Layer 4: IP Allocation (bottom) === -->
+  <rect x="40" y="495" width="820" height="110" rx="12" fill="url(#grad-green)" opacity="0.12" filter="url(#shadow)"/>
+  <rect x="40" y="495" width="6" height="110" rx="3" fill="url(#grad-green)"/>
 
   <!-- IP icon -->
-  <g transform="translate(70, 368)">
+  <g transform="translate(70, 513)">
     <rect x="2" y="5" width="36" height="28" rx="4" fill="none" stroke="#059669" stroke-width="2"/>
     <text x="20" y="25" text-anchor="middle" font-size="14" font-weight="700" fill="#059669">IP</text>
   </g>
 
-  <text x="120" y="376" font-size="16" font-weight="700" fill="#059669">IP Allocation</text>
-  <text x="120" y="394" font-size="12" fill="#64748b">Assigns IP addresses to machines via static pools or DHCP</text>
+  <text x="120" y="521" font-size="16" font-weight="700" fill="#059669">IP Allocation</text>
+  <text x="120" y="539" font-size="12" fill="#64748b">Assigns IP addresses to machines via static pools or DHCP</text>
 
-  <rect x="120" y="408" width="180" height="30" rx="15" fill="#059669" opacity="0.9"/>
-  <text x="210" y="428" text-anchor="middle" font-size="13" font-weight="600" fill="white">static-ip-operator</text>
+  <rect x="120" y="555" width="180" height="30" rx="15" fill="#059669" opacity="0.9"/>
+  <text x="210" y="575" text-anchor="middle" font-size="13" font-weight="600" fill="white">static-ip-operator</text>
 
-  <rect x="315" y="408" width="180" height="30" rx="15" fill="#059669" opacity="0.9"/>
-  <text x="405" y="428" text-anchor="middle" font-size="13" font-weight="600" fill="white">kea-operator</text>
+  <rect x="315" y="555" width="180" height="30" rx="15" fill="#059669" opacity="0.9"/>
+  <text x="405" y="575" text-anchor="middle" font-size="13" font-weight="600" fill="white">kea-operator</text>
 
   <!-- CRD pills -->
-  <rect x="620" y="372" width="180" height="30" rx="15" fill="#059669" opacity="0.15"/>
-  <text x="710" y="392" text-anchor="middle" font-size="13" fill="#059669">IPAllocation</text>
-  <rect x="620" y="408" width="180" height="30" rx="15" fill="#059669" opacity="0.15"/>
-  <text x="710" y="428" text-anchor="middle" font-size="13" fill="#059669">NetworkConfiguration</text>
-
-  <!-- Arrow up -->
-  <g transform="translate(440, 462)">
-    <line x1="0" y1="4" x2="0" y2="26" stroke="#94a3b8" stroke-width="2" stroke-dasharray="4,3"/>
-    <polygon points="-5,8 0,0 5,8" fill="#94a3b8"/>
-  </g>
-  <text x="460" y="480" font-size="11" fill="#94a3b8" font-style="italic">network ready</text>
-
-  <!-- === Layer 1: Network Provisioning (bottom) === -->
-  <rect x="40" y="495" width="820" height="110" rx="12" fill="url(#grad-blue)" opacity="0.12" filter="url(#shadow)"/>
-  <rect x="40" y="495" width="6" height="110" rx="3" fill="url(#grad-blue)"/>
-
-  <!-- Network icon -->
-  <g transform="translate(70, 513)">
-    <circle cx="20" cy="8" r="5" fill="none" stroke="#0284c7" stroke-width="2"/>
-    <circle cx="6" cy="30" r="5" fill="none" stroke="#0284c7" stroke-width="2"/>
-    <circle cx="34" cy="30" r="5" fill="none" stroke="#0284c7" stroke-width="2"/>
-    <line x1="16" y1="12" x2="9" y2="26" stroke="#0284c7" stroke-width="1.5"/>
-    <line x1="24" y1="12" x2="31" y2="26" stroke="#0284c7" stroke-width="1.5"/>
-  </g>
-
-  <text x="120" y="521" font-size="16" font-weight="700" fill="#0284c7">Network Provisioning</text>
-  <text x="120" y="539" font-size="12" fill="#64748b">Provisions network segments with IP prefixes and VLANs</text>
-
-  <rect x="120" y="555" width="180" height="30" rx="15" fill="#0284c7" opacity="0.9"/>
-  <text x="210" y="575" text-anchor="middle" font-size="13" font-weight="600" fill="white">nms-operator</text>
-
-  <rect x="315" y="555" width="280" height="30" rx="15" fill="#0284c7" opacity="0.9"/>
-  <text x="455" y="575" text-anchor="middle" font-size="13" font-weight="600" fill="white">manual-ip-provisioning-operator</text>
-
-  <!-- CRD pill -->
-  <rect x="620" y="555" width="180" height="30" rx="15" fill="#0284c7" opacity="0.15"/>
-  <text x="710" y="575" text-anchor="middle" font-size="13" fill="#0284c7">NetworkNamespace</text>
+  <rect x="620" y="519" width="180" height="30" rx="15" fill="#059669" opacity="0.15"/>
+  <text x="710" y="539" text-anchor="middle" font-size="13" fill="#059669">IPAllocation</text>
+  <rect x="620" y="555" width="180" height="30" rx="15" fill="#059669" opacity="0.15"/>
+  <text x="710" y="575" text-anchor="middle" font-size="13" fill="#059669">NetworkConfiguration</text>
 
   <!-- Legend -->
   <g transform="translate(220, 618)">

--- a/docs/reference/crd/etcdbackup.md
+++ b/docs/reference/crd/etcdbackup.md
@@ -1,0 +1,45 @@
+# EtcdBackup
+
+The EtcdBackup CRD configures etcd backup schedules and retention policies for Kubernetes clusters managed by Viti Stack.
+
+## Resource Definition
+
+```yaml
+apiVersion: vitistack.io/v1alpha1
+kind: EtcdBackup
+metadata:
+  name: string
+  namespace: string
+spec:
+  # Cluster Reference
+  clusterRef:
+    name: string                # KubernetesCluster name
+
+  # Schedule Configuration
+  schedule:
+    cron: string                # Cron expression for backup schedule
+    retention:
+      maxBackups: int           # Maximum number of backups to retain
+      maxAge: string            # Maximum age of backups (e.g., "7d")
+
+  # Storage Configuration
+  storage:
+    type: string                # Storage type: s3, local, nfs
+    s3:
+      bucket: string            # S3 bucket name
+      prefix: string            # Key prefix
+      region: string            # S3 region
+      credentials:
+        secretRef:
+          name: string          # Secret with S3 credentials
+
+status:
+  lastBackup: timestamp         # Last successful backup time
+  lastBackupSize: string        # Size of last backup
+  backupCount: int              # Current number of stored backups
+  conditions: []Condition       # Status conditions
+```
+
+## Related Resources
+
+- [KubernetesCluster](kubernetescluster.md) — Cluster being backed up

--- a/docs/reference/crd/index.md
+++ b/docs/reference/crd/index.md
@@ -1,772 +1,109 @@
 # Custom Resource Definitions (CRDs)
 
-!!! warning "Work in progress!"
+The Viti Stack CRDs define the declarative APIs used by all operators to manage infrastructure resources in Kubernetes.
 
-The Viti Stack Custom Resource Definitions (CRDs) provide declarative API specifications for managing infrastructure resources in Kubernetes clusters. These CRDs define the data structures and schemas used across all Viti Stack operators to ensure consistent resource management and interoperability.
+## API Group and Versions
 
-## API Overview
+All CRDs belong to the **vitistack.io** API group. Most use **v1alpha1**; the network resources have been promoted to **v1alpha2**.
 
-### API Group and Version
+| Version | Applies To | Status |
+|---------|-----------|--------|
+| v1alpha1 | All resources except below | Current |
+| v1alpha2 | NetworkNamespace, IPAllocation | Current (storage version) |
 
-All Viti Stack CRDs belong to the `vitistack.io/v1alpha1` API group:
+!!! info "Conversion Webhook"
+    A standalone conversion webhook ships with the **vitistack-crds** Helm chart and transparently converts **NetworkNamespace** between v1alpha1 and v1alpha2. Existing v1alpha1 clients continue to work without modification.
 
-```yaml
-apiVersion: vitistack.io/v1alpha1
-kind: <ResourceKind>
-```
+## Resources
 
-### Supported Resource Types
+| API Version | Kind | Scope | Purpose |
+|-------------|------|-------|---------|
+| vitistack.io/v1alpha1 | [Vitistack](vitistack.md) | NS | Core infrastructure configuration |
+| vitistack.io/v1alpha1 | [Machine](machine.md) | NS | Virtual machine and compute resource |
+| vitistack.io/v1alpha1 | [MachineClass](machineclass.md) | C | Machine size templates |
+| vitistack.io/v1alpha1 | [MachineProvider](machineprovider.md) | NS | Machine provisioning backend |
+| vitistack.io/v1alpha1 | [KubernetesCluster](kubernetescluster.md) | NS | Kubernetes cluster configuration |
+| vitistack.io/v1alpha1 | [KubernetesProvider](kubernetesprovider.md) | NS | Kubernetes provisioning backend |
+| vitistack.io/v1alpha1 | [NetworkConfiguration](networkconfiguration.md) | NS | Network interface configuration |
+| vitistack.io/**v1alpha2** | [**NetworkNamespace**](networknamespace.md) | NS | Network isolation boundary |
+| vitistack.io/**v1alpha2** | [**IPAllocation**](ipallocation.md) | NS | Individual IP address allocation |
+| vitistack.io/v1alpha1 | ClusterStorage | C | Storage configuration |
+| vitistack.io/v1alpha1 | ClusterStorageClass | C | Storage class templates |
+| vitistack.io/v1alpha1 | [EtcdBackup](etcdbackup.md) | NS | Etcd backup configuration |
+| vitistack.io/v1alpha1 | [KubevirtConfig](kubevirtconfig.md) | NS | KubeVirt operator configuration |
+| vitistack.io/v1alpha1 | [ProxmoxConfig](proxmoxconfig.md) | NS | Proxmox operator configuration |
 
-| Resource | Kind | Scope | Purpose |
-|----------|------|-------|---------|
-| Vitistack | `Vitistack` | Namespaced | Core infrastructure configuration |
-| Machine | `Machine` | Namespaced | Virtual machine and compute resource |
-| Machine Provider | `MachineProvider` | Namespaced | Machine provisioning backend |
-| Kubernetes Cluster | `KubernetesCluster` | Namespaced | Kubernetes cluster configuration |
-| Kubernetes Provider | `KubernetesProvider` | Namespaced | Kubernetes provisioning backend |
-| Network Configuration | `NetworkConfiguration` | Namespaced | Network interface configuration |
-| Network Namespace | `NetworkNamespace` | Namespaced | Network isolation boundary |
-| Load Balancer | `LoadBalancer` | Namespaced | Load balancing configuration |
-| KubeVirt Config | `KubevirtConfig` | Namespaced | KubeVirt operator configuration |
-| Proxmox Config | `ProxmoxConfig` | Namespaced | Proxmox operator configuration |
+## Schema Evolution
 
-## Core Resource Specifications
+### Versioning Strategy
 
-### Vitistack Resource
+- **v1alpha1** — Current for most resources. Breaking changes possible.
+- **v1alpha2** — Storage version for network resources. v1alpha1 still served via conversion webhook.
+- **v1beta1 / v1** — Future stable versions with backward compatibility guarantees.
 
-Primary configuration resource for Viti Stack infrastructure:
+### Conversion Webhook
 
-```yaml
-apiVersion: vitistack.io/v1alpha1
-kind: Vitistack
-metadata:
-  name: string                     # Infrastructure identifier
-  namespace: string               # Kubernetes namespace
-spec:
-  # Infrastructure Configuration
-  infrastructure:
-    providers:
-    - type: string                 # Provider type: proxmox, talos, kubevirt, kea
-      name: string                # Provider instance name
-      endpoint: string            # Provider API endpoint
-      region: string              # Provider region/zone
-      credentials:
-        secretRef:
-          name: string            # Secret containing credentials
-          namespace: string       # Secret namespace
-          
-  # Global Settings
-  settings:
-    defaultStorageClass: string   # Default storage class for volumes
-    defaultNetworkPolicy: string  # Default network policy
-    monitoring:
-      enabled: bool              # Enable monitoring integration
-      namespace: string          # Monitoring namespace
-    logging:
-      enabled: bool              # Enable centralized logging
-      endpoint: string           # Log aggregation endpoint
-      
-  # Resource Quotas
-  quotas:
-    machines:
-      total: int                 # Maximum machines across providers
-      perProvider: int           # Maximum machines per provider
-    storage:
-      total: string              # Total storage quota (e.g., "1Ti")
-      perMachine: string         # Maximum storage per machine
-    network:
-      maxNetworks: int           # Maximum networks per namespace
-      
-status:
-  phase: string                  # Current phase: Pending, Active, Failed
-  conditions: []Condition        # Status conditions
-  providers: []ProviderStatus    # Provider status information
-  resources:
-    machines: int               # Current machine count
-    networks: int               # Current network count
-    storage: string             # Current storage usage
-```
+The **vitistack-crds** Helm chart deploys a standalone conversion webhook for **NetworkNamespace** and **IPAllocation**:
 
-### Machine Resource
+- TLS managed by **cert-manager** (CA auto-injected into CRD spec)
+- Runs as a separate deployment, independent of any operator
+- Converts between v1alpha1 ↔ v1alpha2 transparently
 
-Defines virtual machine or compute resource specifications:
+### Compatibility Rules
 
-```yaml
-apiVersion: vitistack.io/v1alpha1
-kind: Machine
-metadata:
-  name: string
-  namespace: string
-  labels:
-    cluster.vitistack.io/cluster-name: string
-    vitistack.io/provider: string
-spec:
-  # Provider Configuration
-  providerRef:
-    apiVersion: string           # Provider API version
-    kind: string                # Provider kind: MachineProvider
-    name: string                # Provider instance name
-    namespace: string           # Provider namespace
-    
-  # Resource Specification
-  resources:
-    cpu:
-      cores: int                # CPU cores (1-128)
-      threads: int              # Threads per core (1-2)
-      sockets: int              # CPU sockets (1-4)
-    memory:
-      size: string              # Memory size (e.g., "4Gi", "8Gi")
-    gpu:
-      type: string              # GPU type: nvidia, amd, intel
-      count: int                # GPU count
-      model: string             # Specific GPU model
-      
-  # Storage Configuration
-  storage:
-    rootVolume:
-      size: string              # Root volume size
-      storageClass: string      # Storage class name
-      type: string              # Volume type: ssd, hdd, nvme
-    dataVolumes:
-    - name: string              # Volume identifier
-      size: string              # Volume size
-      storageClass: string      # Storage class
-      mountPath: string         # Mount path in VM
-      
-  # Network Configuration
-  networking:
-    interfaces:
-    - name: string              # Interface name
-      networkRef:
-        name: string            # NetworkConfiguration name
-        namespace: string       # Network namespace
-      ipAddress: string         # Static IP (optional)
-      macAddress: string        # MAC address (optional)
-      
-  # Operating System
-  operatingSystem:
-    type: string                # OS type: linux, windows, freebsd
-    distribution: string        # Distribution: ubuntu, centos, windows-server
-    version: string             # OS version
-    image:
-      source: string            # Image source: iso, template, cloud-image
-      url: string               # Image URL or template name
-      
-  # Boot Configuration
-  boot:
-    order: []string             # Boot order: disk, network, cdrom
-    firmware:
-      type: string              # Firmware: bios, uefi
-      secureBoot: bool          # Enable secure boot
-      
-  # Cloud-Init Configuration
-  cloudInit:
-    enabled: bool               # Enable cloud-init
-    userData: string            # Cloud-init user data
-    metaData: string            # Cloud-init metadata
-    networkData: string         # Cloud-init network data
-    
-status:
-  phase: string                 # Machine lifecycle phase
-  conditions: []Condition       # Detailed conditions
-  providerStatus: {}            # Provider-specific status
-  networkStatus:
-    interfaces: []InterfaceStatus
-  addresses:
-    internal: []string          # Internal IP addresses
-    external: []string          # External IP addresses
-```
-
-### NetworkConfiguration Resource
-
-Defines network interface configuration and VLAN settings:
-
-```yaml
-apiVersion: vitistack.io/v1alpha1
-kind: NetworkConfiguration
-metadata:
-  name: string
-  namespace: string
-spec:
-  # Network Identification
-  networkId: string             # Unique network identifier
-  vlan: int                     # VLAN ID (1-4094)
-  
-  # Layer 2 Configuration
-  bridge: string                # Bridge interface name
-  mtu: int                      # Maximum Transmission Unit
-  
-  # IP Configuration
-  ipam:
-    type: string                # IPAM type: static, dhcp, kea
-    subnet: string              # Network subnet (CIDR)
-    gateway: string             # Default gateway
-    dns:
-      servers: []string         # DNS server addresses
-      searchDomains: []string   # DNS search domains
-      
-  # DHCP Configuration (when type=kea)
-  dhcp:
-    enabled: bool               # Enable DHCP server
-    poolStart: string           # DHCP pool start address
-    poolEnd: string             # DHCP pool end address
-    leaseTime: string           # DHCP lease duration
-    reservations:
-    - macAddress: string        # MAC address for reservation
-      ipAddress: string         # Reserved IP address
-      hostname: string          # Reserved hostname
-      
-  # Security Configuration
-  security:
-    isolation: bool             # Enable network isolation
-    firewallRules:
-    - direction: string         # Rule direction: ingress, egress
-      protocol: string          # Protocol: tcp, udp, icmp
-      port: string              # Port or port range
-      source: string            # Source CIDR or IP
-      destination: string       # Destination CIDR or IP
-      action: string            # Action: allow, deny
-      
-status:
-  ready: bool                   # Network readiness status
-  allocatedIPs: []string        # Currently allocated IP addresses
-  connectedMachines: []string   # Connected machine references
-```
-
-### NetworkNamespace Resource
-
-Defines network isolation boundaries and multi-tenancy:
-
-```yaml
-apiVersion: vitistack.io/v1alpha1
-kind: NetworkNamespace
-metadata:
-  name: string
-  namespace: string
-spec:
-  # Isolation Configuration
-  isolation:
-    level: string               # Isolation level: strict, moderate, none
-    allowedNamespaces: []string # Allowed namespace communication
-    
-  # Network Policies
-  defaultPolicy:
-    ingress: string             # Default ingress: allow, deny
-    egress: string              # Default egress: allow, deny
-    
-  # Resource Limits
-  limits:
-    networks: int               # Maximum networks in namespace
-    ipAddresses: int            # Maximum IP addresses
-    bandwidth: string           # Bandwidth limit (e.g., "1Gbps")
-    
-  # Quality of Service
-  qos:
-    class: string               # QoS class: guaranteed, burstable, best-effort
-    priority: int               # Network priority (0-255)
-    
-status:
-  phase: string                 # Namespace phase: Active, Terminating
-  networkCount: int             # Current network count
-  ipAddressCount: int           # Current IP address usage
-```
-
-## Provider Configuration Resources
-
-### MachineProvider Resource
-
-Configuration for machine provisioning backends:
-
-```yaml
-apiVersion: vitistack.io/v1alpha1
-kind: MachineProvider
-metadata:
-  name: string
-  namespace: string
-spec:
-  # Provider Type and Configuration
-  type: string                  # Provider type: proxmox, kubevirt, vmware
-  
-  # Connection Configuration
-  endpoint:
-    url: string                 # Provider API URL
-    insecureSkipTLSVerify: bool # Skip TLS verification
-    timeout: string             # Connection timeout
-    
-  # Authentication
-  credentials:
-    type: string                # Auth type: password, token, certificate
-    secretRef:
-      name: string              # Secret name
-      namespace: string         # Secret namespace
-      
-  # Provider-Specific Configuration
-  config:
-    # Proxmox specific
-    proxmox:
-      node: string              # Default Proxmox node
-      storage: string           # Default storage pool
-      networkBridge: string     # Default network bridge
-      
-    # KubeVirt specific  
-    kubevirt:
-      storageClass: string      # Default storage class
-      networkPolicy: string     # Default network policy
-      
-  # Resource Templates
-  templates:
-  - name: string                # Template name
-    resources:
-      cpu: int                  # CPU cores
-      memory: string            # Memory size
-      storage: string           # Storage size
-      
-  # Capacity Management
-  capacity:
-    maxMachines: int            # Maximum concurrent machines
-    reservedResources:
-      cpu: int                  # Reserved CPU cores
-      memory: string            # Reserved memory
-      storage: string           # Reserved storage
-      
-status:
-  ready: bool                   # Provider readiness
-  capacity:
-    total: ResourceQuota        # Total available resources
-    available: ResourceQuota    # Currently available resources
-    used: ResourceQuota         # Currently used resources
-  machines: int                 # Active machine count
-```
-
-### KubernetesProvider Resource
-
-Configuration for Kubernetes cluster provisioning:
-
-```yaml
-apiVersion: vitistack.io/v1alpha1
-kind: KubernetesProvider
-metadata:
-  name: string
-  namespace: string
-spec:
-  # Provider Configuration
-  type: string                  # Provider type: talos, kubeadm, k3s
-  
-  # Cluster Configuration Template
-  clusterTemplate:
-    kubernetesVersion: string   # Kubernetes version
-    cni:
-      type: string              # CNI type: calico, flannel, cilium
-      config: {}                # CNI-specific configuration
-    controlPlane:
-      replicas: int             # Control plane node count
-      machineTemplate:          # Control plane machine template
-        resources: {}
-    workers:
-    - name: string              # Worker group name
-      replicas: int             # Worker node count
-      machineTemplate:          # Worker machine template
-        resources: {}
-        
-  # Network Configuration
-  networking:
-    podCIDR: string             # Pod network CIDR
-    serviceCIDR: string         # Service network CIDR
-    dnsDomain: string           # Cluster DNS domain
-    
-  # Add-ons Configuration
-  addons:
-    dns:
-      enabled: bool             # Enable CoreDNS
-      config: {}                # DNS configuration
-    ingress:
-      enabled: bool             # Enable ingress controller
-      type: string              # Ingress type: nginx, traefik, istio
-    storage:
-      enabled: bool             # Enable storage classes
-      defaultClass: string      # Default storage class
-      
-status:
-  ready: bool                   # Provider readiness
-  supportedVersions: []string   # Supported Kubernetes versions
-  activeConlusters: int         # Active cluster count
-```
-
-## Operator Configuration Resources
-
-### KubevirtConfig Resource
-
-Configuration for KubeVirt operator integration:
-
-```yaml
-apiVersion: vitistack.io/v1alpha1
-kind: KubevirtConfig
-metadata:
-  name: string
-  namespace: string
-spec:
-  # KubeVirt Configuration
-  kubevirt:
-    version: string             # KubeVirt version
-    namespace: string           # KubeVirt namespace
-    
-  # Feature Gates
-  featureGates:
-  - name: string                # Feature gate name
-    enabled: bool               # Feature enabled status
-    
-  # Resource Configuration
-  resources:
-    vmiCPUModel: string         # Default CPU model
-    machineType: string         # Default machine type
-    emulatedMachines: []string  # Supported emulated machines
-    
-  # Storage Configuration
-  storage:
-    defaultStorageClass: string # Default storage class
-    volumeModes: []string       # Supported volume modes
-    accessModes: []string       # Supported access modes
-    
-  # Network Configuration
-  network:
-    defaultNetworkInterface: string # Default network interface
-    binding: {}                 # Network binding configuration
-    
-status:
-  phase: string                 # Configuration phase
-  appliedVersion: string        # Applied KubeVirt version
-  conditions: []Condition       # Status conditions
-```
-
-### ProxmoxConfig Resource
-
-Configuration for Proxmox operator integration:
-
-```yaml
-apiVersion: vitistack.io/v1alpha1
-kind: ProxmoxConfig
-metadata:
-  name: string
-  namespace: string
-spec:
-  # Proxmox Cluster Configuration
-  cluster:
-    nodes: []string             # Proxmox node list
-    endpoint: string            # Cluster API endpoint
-    
-  # Authentication Configuration
-  authentication:
-    type: string                # Auth type: pam, pve, ad, ldap
-    realm: string               # Authentication realm
-    
-  # Default Configuration
-  defaults:
-    storage: string             # Default storage pool
-    network: string             # Default network bridge
-    osType: string              # Default OS type
-    
-  # Resource Limits
-  limits:
-    maxVMsPerNode: int          # Maximum VMs per node
-    maxCPUCores: int            # Maximum CPU cores per VM
-    maxMemory: string           # Maximum memory per VM
-    
-  # Template Configuration
-  templates:
-  - id: string                  # Template ID
-    name: string                # Template name
-    osType: string              # Operating system type
-    resources: {}               # Default resources
-    
-status:
-  ready: bool                   # Configuration readiness
-  clusterVersion: string        # Proxmox cluster version
-  availableNodes: []string      # Available Proxmox nodes
-```
-
-## Data Type Specifications
-
-### Common Data Types
-
-#### ResourceRequirements
-
-```yaml
-resources:
-  requests:
-    cpu: string                 # CPU request (e.g., "100m", "1")
-    memory: string              # Memory request (e.g., "128Mi", "1Gi")
-    storage: string             # Storage request (e.g., "10Gi")
-  limits:
-    cpu: string                 # CPU limit
-    memory: string              # Memory limit
-    storage: string             # Storage limit
-```
-
-#### Condition
-
-```yaml
-conditions:
-- type: string                  # Condition type
-  status: string                # Status: True, False, Unknown
-  reason: string                # Reason code
-  message: string               # Human-readable message
-  lastTransitionTime: string    # Last transition timestamp
-  observedGeneration: int       # Observed resource generation
-```
-
-#### SecretReference
-
-```yaml
-secretRef:
-  name: string                  # Secret name
-  namespace: string             # Secret namespace (optional)
-  key: string                   # Secret key (optional)
-```
-
-#### ObjectReference
-
-```yaml
-objectRef:
-  apiVersion: string            # Referenced object API version
-  kind: string                  # Referenced object kind
-  name: string                  # Referenced object name
-  namespace: string             # Referenced object namespace
-  uid: string                   # Referenced object UID
-```
-
-### Network Data Types
-
-#### IPAMConfiguration
-
-```yaml
-ipam:
-  type: string                  # IPAM type: static, dhcp, kea, external
-  subnet: string                # Network subnet in CIDR notation
-  gateway: string               # Default gateway address
-  dns:
-    servers: []string           # DNS server addresses
-    searchDomains: []string     # DNS search domains
-  dhcp:
-    enabled: bool               # Enable DHCP
-    poolStart: string           # DHCP pool start
-    poolEnd: string             # DHCP pool end
-    leaseTime: string           # DHCP lease duration
-```
-
-#### NetworkInterface
-
-```yaml
-interfaces:
-- name: string                  # Interface name
-  type: string                  # Interface type: bridge, macvlan, ipvlan
-  macAddress: string            # MAC address
-  mtu: int                      # Maximum Transmission Unit
-  vlan: int                     # VLAN ID
-  ipConfiguration:
-    type: string                # IP config type: static, dhcp
-    address: string             # Static IP address
-    netmask: string             # Network mask
-    gateway: string             # Gateway address
-```
-
-## Validation and Constraints
-
-### Resource Naming Conventions
-
-| Field | Pattern | Example | Description |
-|-------|---------|---------|-------------|
-| `metadata.name` | `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$` | `web-server-01` | RFC 1123 compliant |
-| `spec.networkId` | `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$` | `prod-network` | Network identifier |
-| `spec.vlan` | `1-4094` | `100` | Valid VLAN range |
-
-### Resource Constraints
-
-#### CPU Specifications
-
-| Field | Minimum | Maximum | Default | Format |
-|-------|---------|---------|---------|---------|
-| `cpu.cores` | 1 | 128 | 1 | Integer |
-| `cpu.threads` | 1 | 2 | 1 | Integer |  
-| `cpu.sockets` | 1 | 4 | 1 | Integer |
-
-#### Memory Specifications
-
-| Field | Minimum | Maximum | Format | Example |
-|-------|---------|---------|---------|---------|
-| `memory.size` | 128Mi | 1024Gi | Kubernetes quantity | "4Gi", "512Mi" |
-
-#### Storage Specifications
-
-| Field | Minimum | Maximum | Format | Example |
-|-------|---------|---------|---------|---------|
-| `storage.size` | 1Gi | 100Ti | Kubernetes quantity | "20Gi", "1Ti" |
-
-### Network Constraints
-
-| Field | Validation | Description |
-|-------|------------|-------------|
-| `subnet` | Valid CIDR | Must be valid IPv4/IPv6 CIDR |
-| `ipAddress` | Valid IP | Must be valid IPv4/IPv6 address |
-| `macAddress` | Valid MAC | Must be valid MAC address format |
-| `vlan` | 1-4094 | Must be in valid VLAN range |
-
-## Schema Evolution and Compatibility
-
-### API Version Management
-
-The CRDs follow Kubernetes API versioning conventions:
-
-- **v1alpha1**: Initial API version with breaking changes possible
-- **v1beta1**: Stable API with backward compatibility (future)
-- **v1**: Stable API with long-term compatibility (future)
-
-### Conversion Strategy
-
-When upgrading between API versions:
-
-```yaml
-# Conversion webhook configuration
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: machines.vitistack.io
-spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      service:
-        name: vitistack-conversion-webhook
-        namespace: vitistack-system
-        path: /convert
-```
-
-### Backward Compatibility
-
-| Change Type | v1alpha1 | v1beta1 | v1 |
-|-------------|----------|---------|-----|
+| Change Type | v1alpha | v1beta | v1 |
+|-------------|---------|--------|-----|
 | Add optional field | ✅ | ✅ | ✅ |
 | Add required field | ⚠️ | ❌ | ❌ |
 | Remove field | ⚠️ | ❌ | ❌ |
 | Rename field | ⚠️ | ❌ | ❌ |
 | Change field type | ⚠️ | ❌ | ❌ |
 
-## Integration Patterns
+## Installation
 
-### Go API Integration
+### Helm (recommended)
+
+```bash
+helm install vitistack-crds oci://ghcr.io/vitistack/helm/vitistack-crds \
+  --namespace vitistack-system --create-namespace \
+  --set conversionWebhook.enabled=true
+```
+
+### Manual
+
+```bash
+kubectl apply -f crds/
+```
+
+### Verify
+
+```bash
+kubectl get crd | grep vitistack.io
+```
+
+## Go Integration
 
 ```go
 import (
-    v1alpha1 "github.com/vitistack/crds/pkg/v1alpha1"
+    v1alpha1 "github.com/vitistack/common/pkg/v1alpha1"
+    v1alpha2 "github.com/vitistack/common/pkg/v1alpha2"
     "k8s.io/apimachinery/pkg/runtime"
     "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// Create scheme with CRD types
 scheme := runtime.NewScheme()
 v1alpha1.AddToScheme(scheme)
+v1alpha2.AddToScheme(scheme)
 
-// Create client
-client, err := client.New(config, client.Options{
-    Scheme: scheme,
+c, _ := client.New(config, client.Options{Scheme: scheme})
+
+// Fetch a v1alpha2 NetworkNamespace
+nn := &v1alpha2.NetworkNamespace{}
+_ = c.Get(ctx, types.NamespacedName{Namespace: "dc-01", Name: "prod"}, nn)
+
+// List IPAllocations by label
+list := &v1alpha2.IPAllocationList{}
+_ = c.List(ctx, list, client.MatchingLabels{
+    v1alpha2.LabelNetworkNamespace: "prod",
 })
-
-// Use typed resources
-machine := &v1alpha1.Machine{}
-err = client.Get(ctx, types.NamespacedName{
-    Namespace: "default",
-    Name: "my-machine",
-}, machine)
 ```
-
-### Unstructured Conversion
-
-```go
-import (
-    unstructuredutil "github.com/vitistack/crds/pkg/unstructuredutil"
-    v1alpha1 "github.com/vitistack/crds/pkg/v1alpha1"
-)
-
-// Convert typed to unstructured
-machine := &v1alpha1.Machine{/* ... */}
-unstructured, err := unstructuredutil.MachineToUnstructured(machine)
-
-// Convert unstructured to typed
-typed, err := unstructuredutil.MachineFromUnstructured(unstructured)
-```
-
-### Dynamic Client Usage
-
-```go
-import (
-    "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-    "k8s.io/apimachinery/pkg/runtime/schema"
-    "k8s.io/client-go/dynamic"
-)
-
-// Create dynamic client
-dynamicClient, err := dynamic.NewForConfig(config)
-
-// Define GVR
-machineGVR := schema.GroupVersionResource{
-    Group:    "vitistack.io",
-    Version:  "v1alpha1", 
-    Resource: "machines",
-}
-
-// Create resource
-machine := &unstructured.Unstructured{
-    Object: map[string]interface{}{
-        "apiVersion": "vitistack.io/v1alpha1",
-        "kind":       "Machine",
-        // ... spec
-    },
-}
-
-result, err := dynamicClient.Resource(machineGVR).
-    Namespace("default").
-    Create(ctx, machine, metav1.CreateOptions{})
-```
-
-## Installation and Management
-
-### CRD Installation
-
-```bash
-# Install all CRDs
-make install-crds
-
-# Install specific CRD
-kubectl apply -f crds/vitistack.io_machines.yaml
-
-# Verify installation
-kubectl get crd | grep vitistack.io
-```
-
-### CRD Generation
-
-```bash
-# Generate CRDs from Go types
-make manifests
-
-# Generate deep copy methods
-make generate
-
-# Sanitize CRDs (remove unsupported integer formats)
-make sanitize-crds
-
-# Verify sanitized CRDs
-make verify-crds
-```
-
-### Development Workflow
-
-```bash
-# Full development cycle
-make generate     # Generate code
-make manifests   # Generate CRDs
-make sanitize-crds # Clean up CRDs
-make test        # Run tests
-make lint        # Lint code
-```
-
-This reference documentation provides comprehensive technical specifications for all Viti Stack CRDs, assuming familiarity with Kubernetes Custom Resource Definitions, API design patterns, and infrastructure as code concepts.

--- a/docs/reference/crd/ipallocation.md
+++ b/docs/reference/crd/ipallocation.md
@@ -1,0 +1,191 @@
+# IPAllocation
+
+The IPAllocation CRD represents a single IP address allocation within a [NetworkNamespace](networknamespace.md). It replaces the inline allocatedIPs array from v1alpha1, making each allocation a first-class Kubernetes resource with its own lifecycle.
+
+## API Version
+
+| Version | Status |
+|---------|--------|
+| vitistack.io/v1alpha2 | Current |
+
+!!! info "New in v1alpha2"
+    IPAllocation is a new resource introduced in v1alpha2. It does not exist in v1alpha1.
+
+## Design Principles
+
+- **One resource per allocation** — Each IP address gets its own IPAllocation CR, enabling fine-grained status tracking and garbage collection.
+- **Owner references** — Each IPAllocation is owned (via ownerReferences) by its parent NetworkConfiguration, so it is automatically garbage-collected when the NC is deleted.
+- **Label-based lookups** — Standard labels enable efficient listing by NetworkNamespace or NetworkConfiguration without scanning all resources.
+
+## Resource Definition
+
+```yaml
+apiVersion: vitistack.io/v1alpha2
+kind: IPAllocation
+metadata:
+  name: string
+  namespace: string
+  labels:
+    vitistack.io/network-namespace: string       # Parent NetworkNamespace name
+    vitistack.io/network-configuration: string   # Parent NetworkConfiguration name
+  ownerReferences:
+    - apiVersion: vitistack.io/v1alpha1
+      kind: NetworkConfiguration
+      name: string
+      uid: string
+spec:
+  networkNamespaceName: string           # Required. NetworkNamespace this belongs to
+  networkConfigurationName: string       # Required. NetworkConfiguration that requested it
+  interfaceName: string                  # Optional. NIC name for multi-NIC VMs
+  requestedAddress: string               # Optional. Preferred IP address
+
+status:
+  phase: Pending | Allocated | Released | Error
+  address: string                        # Allocated IPv4 address
+  gateway: string                        # Gateway for the subnet
+  prefix: int                            # CIDR prefix length (e.g. 24)
+  vlanId: int                            # VLAN ID
+  dns: []string                          # DNS server addresses
+  expiresAt: timestamp                   # TTL expiry (for static with TTL)
+  message: string                        # Human-readable status detail
+```
+
+## Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> Pending: IPAllocation created
+    Pending --> Allocated: Address assigned
+    Pending --> Error: Pool exhausted / conflict
+    Allocated --> Released: NetworkConfiguration deleted
+    Error --> Pending: Reconcile retry
+    Released --> [*]: Garbage collected
+```
+
+| Phase | Description |
+|-------|-------------|
+| Pending | Allocation requested but not yet fulfilled. |
+| Allocated | IP address successfully assigned. status.address is populated. |
+| Released | The allocation has been released (NC deleted). Will be garbage-collected. |
+| Error | Allocation failed. See status.message for details. |
+
+## Usage Examples
+
+### Typical Allocation (created by static-ip-operator)
+
+```yaml
+apiVersion: vitistack.io/v1alpha2
+kind: IPAllocation
+metadata:
+  name: web-server-01-eth0
+  namespace: datacenter-01
+  labels:
+    vitistack.io/network-namespace: prod-network
+    vitistack.io/network-configuration: web-server-01
+  ownerReferences:
+    - apiVersion: vitistack.io/v1alpha1
+      kind: NetworkConfiguration
+      name: web-server-01
+      uid: "abc-123"
+spec:
+  networkNamespaceName: prod-network
+  networkConfigurationName: web-server-01
+  interfaceName: eth0
+status:
+  phase: Allocated
+  address: "10.0.2.50"
+  gateway: "10.0.2.1"
+  prefix: 24
+  vlanId: 100
+  dns:
+    - "8.8.8.8"
+    - "8.8.4.4"
+  expiresAt: "2026-05-19T10:00:00Z"
+```
+
+### Requesting a Specific Address
+
+```yaml
+apiVersion: vitistack.io/v1alpha2
+kind: IPAllocation
+metadata:
+  name: db-server-fixed
+  namespace: datacenter-01
+  labels:
+    vitistack.io/network-namespace: prod-network
+    vitistack.io/network-configuration: db-server-01
+spec:
+  networkNamespaceName: prod-network
+  networkConfigurationName: db-server-01
+  requestedAddress: "10.0.2.100"
+```
+
+The allocator will honor the request if the address is within the pool range and not already allocated.
+
+## Labels
+
+IPAllocation resources carry standard labels for efficient querying:
+
+| Label | Purpose | Example |
+|-------|---------|---------|
+| vitistack.io/network-namespace | Parent NetworkNamespace | prod-network |
+| vitistack.io/network-configuration | Parent NetworkConfiguration | web-server-01 |
+
+### Listing Allocations by NetworkNamespace
+
+```bash
+kubectl get ipallocations -l vitistack.io/network-namespace=prod-network
+```
+
+### Listing Allocations by NetworkConfiguration
+
+```bash
+kubectl get ipallocations -l vitistack.io/network-configuration=web-server-01
+```
+
+## Print Columns
+
+```
+NAME                ADDRESS      NETWORKNAMESPACE   NETWORKCONFIGURATION   PHASE       AGE
+web-server-01-eth0  10.0.2.50    prod-network       web-server-01          Allocated   5m
+db-server-fixed     10.0.2.100   prod-network       db-server-01           Allocated   3m
+new-server-eth0     <none>       prod-network       new-server             Pending     10s
+```
+
+## Operator Responsibilities
+
+### static-ip-operator
+
+Creates and manages IPAllocation resources for NetworkNamespaces with ipAllocation.type: static:
+
+1. Watches NetworkConfiguration resources
+2. When a NC references a NetworkNamespace with static allocation, creates an IPAllocation CR
+3. Allocates the next available IP from the pool (or the requested address)
+4. Updates status.phase to Allocated with the assigned address details
+5. Handles TTL expiry and re-allocation
+
+### kea-operator
+
+Does **not** create IPAllocation resources. DHCP-based allocations are managed by the Kea DHCP server directly. The aggregate counts in NetworkNamespace.status.ipAllocationSummary are computed from Kea lease data.
+
+## Relationship to NetworkNamespace
+
+The IPAllocationSummary in NetworkNamespace.status provides aggregate counts computed from individual IPAllocation resources:
+
+```yaml
+# NetworkNamespace status (computed projection)
+status:
+  ipAllocationSummary:
+    type: static
+    provider: static-ip-operator
+    allocatedCount: 15
+    availableCount: 235
+    totalCount: 250
+```
+
+This is a read-only projection — the source of truth is the set of IPAllocation CRs.
+
+## Related Resources
+
+- [NetworkNamespace](networknamespace.md) — The network segment that contains the IP pool
+- [NetworkConfiguration](../operators/kea-operator.md) — Machine network interface that triggers allocation

--- a/docs/reference/crd/kubernetescluster.md
+++ b/docs/reference/crd/kubernetescluster.md
@@ -1,0 +1,48 @@
+# KubernetesCluster
+
+The KubernetesCluster CRD defines a Kubernetes cluster managed by Viti Stack. It references a provider and specifies the desired cluster configuration.
+
+## Resource Definition
+
+```yaml
+apiVersion: vitistack.io/v1alpha1
+kind: KubernetesCluster
+metadata:
+  name: string
+  namespace: string
+spec:
+  # Provider Reference
+  providerRef:
+    name: string                # KubernetesProvider name
+    namespace: string           # Provider namespace
+
+  # Cluster Configuration
+  kubernetesVersion: string     # Desired Kubernetes version
+  controlPlane:
+    replicas: int               # Control plane node count
+    machineClass: string        # MachineClass reference
+
+  # Worker Node Groups
+  workers:
+  - name: string                # Worker group name
+    replicas: int               # Node count
+    machineClass: string        # MachineClass reference
+
+  # Network Configuration
+  networking:
+    podCIDR: string             # Pod network CIDR
+    serviceCIDR: string         # Service network CIDR
+
+status:
+  phase: string                 # Cluster phase: Provisioning, Running, Failed
+  kubernetesVersion: string     # Actual running version
+  conditions: []Condition       # Status conditions
+  controlPlaneReady: bool       # Control plane readiness
+  nodes: int                    # Total node count
+```
+
+## Related Resources
+
+- [KubernetesProvider](kubernetesprovider.md) — Provider that provisions this cluster
+- [Machine](machine.md) — Machines forming the cluster nodes
+- [EtcdBackup](etcdbackup.md) — Backup configuration for this cluster

--- a/docs/reference/crd/kubernetesprovider.md
+++ b/docs/reference/crd/kubernetesprovider.md
@@ -1,0 +1,66 @@
+# KubernetesProvider
+
+The KubernetesProvider CRD configures Kubernetes cluster provisioning backends. It defines cluster templates, networking, and add-on configuration.
+
+## Resource Definition
+
+```yaml
+apiVersion: vitistack.io/v1alpha1
+kind: KubernetesProvider
+metadata:
+  name: string
+  namespace: string
+spec:
+  # Provider Configuration
+  type: string                  # Provider type: talos, kubeadm, k3s
+
+  # Cluster Configuration Template
+  clusterTemplate:
+    kubernetesVersion: string   # Kubernetes version
+    cni:
+      type: string              # CNI type: calico, flannel, cilium
+      config: {}                # CNI-specific configuration
+    controlPlane:
+      replicas: int             # Control plane node count
+      machineTemplate:          # Control plane machine template
+        resources: {}
+    workers:
+    - name: string              # Worker group name
+      replicas: int             # Worker node count
+      machineTemplate:          # Worker machine template
+        resources: {}
+
+  # Network Configuration
+  networking:
+    podCIDR: string             # Pod network CIDR
+    serviceCIDR: string         # Service network CIDR
+    dnsDomain: string           # Cluster DNS domain
+
+  # Add-ons Configuration
+  addons:
+    dns:
+      enabled: bool             # Enable CoreDNS
+      config: {}                # DNS configuration
+    ingress:
+      enabled: bool             # Enable ingress controller
+      type: string              # Ingress type: nginx, traefik, istio
+    storage:
+      enabled: bool             # Enable storage classes
+      defaultClass: string      # Default storage class
+
+status:
+  ready: bool                   # Provider readiness
+  supportedVersions: []string   # Supported Kubernetes versions
+  activeClusters: int           # Active cluster count
+```
+
+## Supported Provider Types
+
+| Type | Description | Operator |
+|------|-------------|----------|
+| talos | Talos Linux clusters | talos-operator |
+
+## Related Resources
+
+- [KubernetesCluster](kubernetescluster.md) — Clusters provisioned by this provider
+- [Machine](machine.md) — Machines that form cluster nodes

--- a/docs/reference/crd/kubevirtconfig.md
+++ b/docs/reference/crd/kubevirtconfig.md
@@ -1,0 +1,50 @@
+# KubevirtConfig
+
+The KubevirtConfig CRD configures the KubeVirt operator integration, defining feature gates, resource defaults, and network bindings.
+
+## Resource Definition
+
+```yaml
+apiVersion: vitistack.io/v1alpha1
+kind: KubevirtConfig
+metadata:
+  name: string
+  namespace: string
+spec:
+  # KubeVirt Configuration
+  kubevirt:
+    version: string             # KubeVirt version
+    namespace: string           # KubeVirt namespace
+
+  # Feature Gates
+  featureGates:
+  - name: string                # Feature gate name
+    enabled: bool               # Feature enabled status
+
+  # Resource Configuration
+  resources:
+    vmiCPUModel: string         # Default CPU model
+    machineType: string         # Default machine type
+    emulatedMachines: []string  # Supported emulated machines
+
+  # Storage Configuration
+  storage:
+    defaultStorageClass: string # Default storage class
+    volumeModes: []string       # Supported volume modes
+    accessModes: []string       # Supported access modes
+
+  # Network Configuration
+  network:
+    defaultNetworkInterface: string # Default network interface
+    binding: {}                 # Network binding configuration
+
+status:
+  phase: string                 # Configuration phase
+  appliedVersion: string        # Applied KubeVirt version
+  conditions: []Condition       # Status conditions
+```
+
+## Related Resources
+
+- [Machine](machine.md) — VMs managed through KubeVirt
+- [MachineProvider](machineprovider.md) — Provider of type kubevirt

--- a/docs/reference/crd/machine.md
+++ b/docs/reference/crd/machine.md
@@ -1,0 +1,109 @@
+# Machine
+
+The Machine CRD defines a virtual machine or compute resource managed by Viti Stack. It specifies hardware resources, networking, storage, and OS configuration.
+
+## Resource Definition
+
+```yaml
+apiVersion: vitistack.io/v1alpha1
+kind: Machine
+metadata:
+  name: string
+  namespace: string
+  labels:
+    cluster.vitistack.io/cluster-name: string
+    vitistack.io/provider: string
+spec:
+  # Provider Configuration
+  providerRef:
+    apiVersion: string           # Provider API version
+    kind: string                # Provider kind: MachineProvider
+    name: string                # Provider instance name
+    namespace: string           # Provider namespace
+
+  # Resource Specification
+  resources:
+    cpu:
+      cores: int                # CPU cores (1-128)
+      threads: int              # Threads per core (1-2)
+      sockets: int              # CPU sockets (1-4)
+    memory:
+      size: string              # Memory size (e.g., "4Gi", "8Gi")
+    gpu:
+      type: string              # GPU type: nvidia, amd, intel
+      count: int                # GPU count
+      model: string             # Specific GPU model
+
+  # Storage Configuration
+  storage:
+    rootVolume:
+      size: string              # Root volume size
+      storageClass: string      # Storage class name
+      type: string              # Volume type: ssd, hdd, nvme
+    dataVolumes:
+    - name: string              # Volume identifier
+      size: string              # Volume size
+      storageClass: string      # Storage class
+      mountPath: string         # Mount path in VM
+
+  # Network Configuration
+  networking:
+    interfaces:
+    - name: string              # Interface name
+      networkRef:
+        name: string            # NetworkConfiguration name
+        namespace: string       # Network namespace
+      ipAddress: string         # Static IP (optional)
+      macAddress: string        # MAC address (optional)
+
+  # Operating System
+  operatingSystem:
+    type: string                # OS type: linux, windows, freebsd
+    distribution: string        # Distribution: ubuntu, centos, windows-server
+    version: string             # OS version
+    image:
+      source: string            # Image source: iso, template, cloud-image
+      url: string               # Image URL or template name
+
+  # Boot Configuration
+  boot:
+    order: []string             # Boot order: disk, network, cdrom
+    firmware:
+      type: string              # Firmware: bios, uefi
+      secureBoot: bool          # Enable secure boot
+
+  # Cloud-Init Configuration
+  cloudInit:
+    enabled: bool               # Enable cloud-init
+    userData: string            # Cloud-init user data
+    metaData: string            # Cloud-init metadata
+    networkData: string         # Cloud-init network data
+
+status:
+  phase: string                 # Machine lifecycle phase
+  conditions: []Condition       # Detailed conditions
+  providerStatus: {}            # Provider-specific status
+  networkStatus:
+    interfaces: []InterfaceStatus
+  addresses:
+    internal: []string          # Internal IP addresses
+    external: []string          # External IP addresses
+```
+
+## Lifecycle Phases
+
+| Phase | Description |
+|-------|-------------|
+| Pending | Machine creation requested but not yet started |
+| Provisioning | Machine is being created by the provider |
+| Running | Machine is running and accessible |
+| Stopping | Machine is shutting down |
+| Stopped | Machine is stopped |
+| Failed | Machine provisioning or operation failed |
+| Deleting | Machine is being destroyed |
+
+## Related Resources
+
+- [MachineProvider](machineprovider.md) — Backend that provisions the machine
+- [NetworkConfiguration](networkconfiguration.md) — Network interfaces attached to the machine
+- [KubernetesCluster](kubernetescluster.md) — Cluster that the machine may belong to

--- a/docs/reference/crd/machineclass.md
+++ b/docs/reference/crd/machineclass.md
@@ -1,0 +1,52 @@
+# MachineClass
+
+The MachineClass CRD defines reusable machine size templates at the cluster scope. Machine resources reference these classes to avoid repeating resource specifications.
+
+## Resource Definition
+
+```yaml
+apiVersion: vitistack.io/v1alpha1
+kind: MachineClass
+metadata:
+  name: string                  # Cluster-scoped (no namespace)
+spec:
+  # Resource Specification
+  resources:
+    cpu:
+      cores: int                # CPU cores
+      threads: int              # Threads per core
+      sockets: int              # CPU sockets
+    memory:
+      size: string              # Memory size (e.g., "4Gi")
+    storage:
+      rootVolume:
+        size: string            # Root volume size
+        storageClass: string    # Storage class
+
+  # Description
+  description: string           # Human-readable description
+```
+
+## Example
+
+```yaml
+apiVersion: vitistack.io/v1alpha1
+kind: MachineClass
+metadata:
+  name: medium
+spec:
+  description: "Medium VM: 4 cores, 8Gi RAM, 40Gi disk"
+  resources:
+    cpu:
+      cores: 4
+    memory:
+      size: "8Gi"
+    storage:
+      rootVolume:
+        size: "40Gi"
+```
+
+## Related Resources
+
+- [Machine](machine.md) — Machines that reference a MachineClass
+- [KubernetesCluster](kubernetescluster.md) — Clusters that use MachineClass for node sizing

--- a/docs/reference/crd/machineprovider.md
+++ b/docs/reference/crd/machineprovider.md
@@ -1,0 +1,79 @@
+# MachineProvider
+
+The MachineProvider CRD configures machine provisioning backends. It defines connection details, credentials, and capacity for a specific infrastructure provider.
+
+## Resource Definition
+
+```yaml
+apiVersion: vitistack.io/v1alpha1
+kind: MachineProvider
+metadata:
+  name: string
+  namespace: string
+spec:
+  # Provider Type and Configuration
+  type: string                  # Provider type: proxmox, kubevirt, vmware
+
+  # Connection Configuration
+  endpoint:
+    url: string                 # Provider API URL
+    insecureSkipTLSVerify: bool # Skip TLS verification
+    timeout: string             # Connection timeout
+
+  # Authentication
+  credentials:
+    type: string                # Auth type: password, token, certificate
+    secretRef:
+      name: string              # Secret name
+      namespace: string         # Secret namespace
+
+  # Provider-Specific Configuration
+  config:
+    # Proxmox specific
+    proxmox:
+      node: string              # Default Proxmox node
+      storage: string           # Default storage pool
+      networkBridge: string     # Default network bridge
+
+    # KubeVirt specific
+    kubevirt:
+      storageClass: string      # Default storage class
+      networkPolicy: string     # Default network policy
+
+  # Resource Templates
+  templates:
+  - name: string                # Template name
+    resources:
+      cpu: int                  # CPU cores
+      memory: string            # Memory size
+      storage: string           # Storage size
+
+  # Capacity Management
+  capacity:
+    maxMachines: int            # Maximum concurrent machines
+    reservedResources:
+      cpu: int                  # Reserved CPU cores
+      memory: string            # Reserved memory
+      storage: string           # Reserved storage
+
+status:
+  ready: bool                   # Provider readiness
+  capacity:
+    total: ResourceQuota        # Total available resources
+    available: ResourceQuota    # Currently available resources
+    used: ResourceQuota         # Currently used resources
+  machines: int                 # Active machine count
+```
+
+## Supported Provider Types
+
+| Type | Description | Operator |
+|------|-------------|----------|
+| proxmox | Proxmox VE hypervisor | proxmox-operator |
+| kubevirt | KubeVirt virtual machines | kubevirt-operator |
+
+## Related Resources
+
+- [Machine](machine.md) — Machines provisioned by this provider
+- [ProxmoxConfig](proxmoxconfig.md) — Proxmox-specific operator settings
+- [KubevirtConfig](kubevirtconfig.md) — KubeVirt-specific operator settings

--- a/docs/reference/crd/networkconfiguration.md
+++ b/docs/reference/crd/networkconfiguration.md
@@ -1,0 +1,67 @@
+# NetworkConfiguration
+
+The NetworkConfiguration CRD defines network interface configuration and VLAN settings for machines. It represents a machine's connection to a network segment.
+
+## Resource Definition
+
+```yaml
+apiVersion: vitistack.io/v1alpha1
+kind: NetworkConfiguration
+metadata:
+  name: string
+  namespace: string
+spec:
+  # Network Identification
+  networkId: string             # Unique network identifier
+  vlan: int                     # VLAN ID (1-4094)
+
+  # Layer 2 Configuration
+  bridge: string                # Bridge interface name
+  mtu: int                      # Maximum Transmission Unit
+
+  # IP Configuration
+  ipam:
+    type: string                # IPAM type: static, dhcp, kea
+    subnet: string              # Network subnet (CIDR)
+    gateway: string             # Default gateway
+    dns:
+      servers: []string         # DNS server addresses
+      searchDomains: []string   # DNS search domains
+
+  # DHCP Configuration (when type=kea)
+  dhcp:
+    enabled: bool               # Enable DHCP server
+    poolStart: string           # DHCP pool start address
+    poolEnd: string             # DHCP pool end address
+    leaseTime: string           # DHCP lease duration
+    reservations:
+    - macAddress: string        # MAC address for reservation
+      ipAddress: string         # Reserved IP address
+      hostname: string          # Reserved hostname
+
+  # Security Configuration
+  security:
+    isolation: bool             # Enable network isolation
+    firewallRules:
+    - direction: string         # Rule direction: ingress, egress
+      protocol: string          # Protocol: tcp, udp, icmp
+      port: string              # Port or port range
+      source: string            # Source CIDR or IP
+      destination: string       # Destination CIDR or IP
+      action: string            # Action: allow, deny
+
+status:
+  ready: bool                   # Network readiness status
+  allocatedIPs: []string        # Currently allocated IP addresses
+  connectedMachines: []string   # Connected machine references
+```
+
+## Relationship to NetworkNamespace
+
+A NetworkConfiguration references a [NetworkNamespace](networknamespace.md) to determine which network segment and IP pool it belongs to. When using static IP allocation, the static-ip-operator creates an [IPAllocation](ipallocation.md) resource for each NetworkConfiguration that requests an address.
+
+## Related Resources
+
+- [NetworkNamespace](networknamespace.md) — The network segment this configuration belongs to
+- [IPAllocation](ipallocation.md) — Individual IP allocations created for this configuration
+- [Machine](machine.md) — Machine that uses this network interface

--- a/docs/reference/crd/networknamespace.md
+++ b/docs/reference/crd/networknamespace.md
@@ -1,0 +1,308 @@
+# NetworkNamespace
+
+The NetworkNamespace CRD defines a network isolation boundary within a Viti Stack datacenter. It represents a logical network segment with its own IP prefix, VLAN, and provisioning lifecycle.
+
+## API Versions
+
+| Version | Status | Storage |
+|---------|--------|--------|
+| v1alpha2 | Current | Yes (storage version) |
+| v1alpha1 | Deprecated | No (served via conversion webhook) |
+
+!!! info "Conversion Webhook"
+    A standalone conversion webhook (deployed with the vitistack-crds Helm chart) handles transparent conversion between v1alpha1 and v1alpha2. Existing v1alpha1 clients continue to work without modification.
+
+## Key Concepts (v1alpha2)
+
+v1alpha2 introduces a clear separation between two concerns:
+
+1. **Network Provisioning** — _Where does the IP prefix and VLAN come from?_
+2. **IP Allocation** — _How are individual IPs assigned to machines within that network?_
+
+This separation enables pluggable provisioning backends (NAM or manual) independent of the IP allocation strategy (DHCP or static).
+
+```mermaid
+graph LR
+    A[NetworkNamespace] -->|networkProvisioning| B{Provider}
+    B -->|nam| C[Default Backend]
+    B -->|manual| D[User-supplied config]
+    B -->|custom| H[Enterprise IPAM]
+    A -->|ipAllocation| E{Type}
+    E -->|dhcp| F[Kea Operator]
+    E -->|static| G[Static IP Operator]
+```
+
+## Resource Definition
+
+```yaml
+apiVersion: vitistack.io/v1alpha2
+kind: NetworkNamespace
+metadata:
+  name: string
+  namespace: string
+spec:
+  datacenterIdentifier: string        # Required. Datacenter ID (e.g. "no-west-az1")
+  supervisorIdentifier: string        # Required. Unique name per datacenter
+
+  networkProvisioning:                # Optional. Defaults to NAM
+    provider: nam | manual            # Network segment source
+    nam: {}                           # Reserved for future NAM overrides
+    manual:                           # Required when provider=manual
+      ipv4CIDR: string               # Subnet in CIDR notation
+      ipv4Gateway: string            # Default gateway
+      ipv6CIDR: string               # IPv6 subnet (optional)
+      vlanId: int                    # VLAN ID (0-4094)
+
+  ipAllocation:                       # Optional. Defaults to DHCP
+    type: dhcp | static              # IP allocation method
+    provider: string                 # Operator name (e.g. "kea", "static-ip-operator")
+    static:                          # Required when type=static
+      ipv4CIDR: string              # Pool subnet
+      ipv4Gateway: string           # Gateway
+      ipv4RangeStart: string        # First allocatable IP
+      ipv4RangeEnd: string          # Last allocatable IP
+      vlanId: int                   # VLAN ID
+      dns: []string                 # DNS servers
+      ttlSeconds: int               # Allocation TTL (default: 3600)
+    dhcp:                            # Optional DHCP overrides
+      requireClientClasses: []string # Kea client classes
+
+status:
+  provisioningPhase: Pending | Ready | Error  # Network provisioning state
+  phase: string                       # Overall lifecycle phase
+  status: string                      # Human-readable status
+  message: string                     # Detail message
+  created: timestamp                  # Creation time
+  observedGeneration: int             # Last observed generation
+  retryCount: int                     # Retry attempts
+
+  # Provisioned network details (populated by provisioning provider)
+  datacenterIdentifier: string
+  supervisorIdentifier: string
+  namespaceId: string                 # External namespace ID
+  ipv4Prefix: string                  # Allocated IPv4 prefix
+  ipv6Prefix: string                  # Allocated IPv6 prefix
+  ipv4EgressIp: string               # Egress IPv4 address
+  ipv6EgressIp: string               # Egress IPv6 address
+  vlanId: int                         # Assigned VLAN ID
+  associatedKubernetesClusterIds: []string
+
+  ipAllocationSummary:                # Aggregate IP allocation state
+    type: dhcp | static
+    provider: string
+    allocatedCount: int
+    availableCount: int
+    totalCount: int
+
+  conditions: []Condition             # Standard Kubernetes conditions
+```
+
+## Provisioning Providers
+
+The networkProvisioning.provider field selects which backend provisions the network segment. The architecture is extensible — any operator that watches NetworkNamespace resources and sets status.provisioningPhase: Ready can serve as a provisioning provider.
+
+### Built-in Providers
+
+| Provider | Description |
+|----------|-------------|
+| nam | Default. Internal network provisioning backend. |
+| manual | User-supplied network configuration (no external system). |
+
+### Enterprise IPAM Integration
+
+The provisioning provider model is designed to support enterprise IPAM integrations (e.g. Infoblox, NetBox, phpIPAM, Bluecat). To build a custom IPAM provisioning operator:
+
+1. **Watch** NetworkNamespace resources where spec.networkProvisioning.provider matches your operator's name
+2. **Allocate** an IP prefix and VLAN from your IPAM system using the datacenterIdentifier and supervisorIdentifier as context
+3. **Populate** status fields: ipv4Prefix, ipv6Prefix, vlanId, namespaceId
+4. **Set** status.provisioningPhase: Ready to ungate downstream IP allocation operators
+
+```go
+// Skeleton reconciler for a custom IPAM provisioning operator
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+    nn := &v1alpha2.NetworkNamespace{}
+    if err := r.Get(ctx, req.NamespacedName, nn); err != nil {
+        return ctrl.Result{}, client.IgnoreNotFound(err)
+    }
+
+    // Only handle our provider
+    if nn.Spec.NetworkProvisioning == nil || 
+       nn.Spec.NetworkProvisioning.Provider != "my-ipam" {
+        return ctrl.Result{}, nil
+    }
+
+    // Call external IPAM API
+    prefix, vlan, err := r.IPAMClient.AllocatePrefix(ctx, 
+        nn.Spec.DatacenterIdentifier, 
+        nn.Spec.SupervisorIdentifier)
+    if err != nil {
+        nn.Status.ProvisioningPhase = v1alpha2.ProvisioningPhaseError
+        nn.Status.Message = err.Error()
+        return ctrl.Result{}, r.Status().Update(ctx, nn)
+    }
+
+    // Populate status
+    nn.Status.IPv4Prefix = prefix.IPv4CIDR
+    nn.Status.VlanID = vlan.ID
+    nn.Status.ProvisioningPhase = v1alpha2.ProvisioningPhaseReady
+    return ctrl.Result{}, r.Status().Update(ctx, nn)
+}
+```
+
+To register a custom provider, add your enum value to the NetworkProvisioningType validation in the CRD schema and deploy your operator alongside the vitistack-crds chart.
+
+### NAM Provider — Default
+
+The default provisioning backend. When networkProvisioning is omitted or set to provider: nam, the nms-operator handles network segment provisioning.
+
+```yaml
+apiVersion: vitistack.io/v1alpha2
+kind: NetworkNamespace
+metadata:
+  name: prod-network
+  namespace: datacenter-01
+spec:
+  datacenterIdentifier: no-west-az1
+  supervisorIdentifier: sv-01
+  # networkProvisioning is omitted → defaults to nam
+  ipAllocation:
+    type: dhcp
+    provider: kea
+```
+
+### Manual Provisioning
+
+Manual provisioning allows operators to supply network configuration directly. This is useful for environments where IP prefixes and VLANs are managed externally or by a separate team.
+
+The manual-ip-provisioning-operator watches for NetworkNamespace resources with provider: manual and sets provisioningPhase: Ready after populating status fields from the manual config.
+
+```yaml
+apiVersion: vitistack.io/v1alpha2
+kind: NetworkNamespace
+metadata:
+  name: manual-network
+  namespace: datacenter-01
+spec:
+  datacenterIdentifier: no-west-az1
+  supervisorIdentifier: sv-01
+  networkProvisioning:
+    provider: manual
+    manual:
+      ipv4CIDR: "10.0.2.0/24"
+      ipv4Gateway: "10.0.2.1"
+      vlanId: 100
+  ipAllocation:
+    type: static
+    provider: static-ip-operator
+    static:
+      ipv4CIDR: "10.0.2.0/24"
+      ipv4Gateway: "10.0.2.1"
+      ipv4RangeStart: "10.0.2.10"
+      ipv4RangeEnd: "10.0.2.250"
+      vlanId: 100
+      dns:
+        - "8.8.8.8"
+        - "8.8.4.4"
+      ttlSeconds: 7200
+```
+
+## Provisioning Phase Lifecycle
+
+The status.provisioningPhase field gates downstream operators:
+
+```mermaid
+stateDiagram-v2
+    [*] --> Pending: NetworkNamespace created
+    Pending --> Ready: Provisioning provider completes
+    Pending --> Error: Provisioning failed
+    Error --> Pending: Reconcile retry
+    Ready --> [*]: Downstream operators proceed
+```
+
+| Phase | Description |
+|-------|-------------|
+| Pending | Network segment is being provisioned. Downstream operators must wait. |
+| Ready | Network is provisioned. IP allocation operators may begin allocating. |
+| Error | Provisioning failed. Check status.message for details. |
+
+!!! warning "Downstream Gating"
+    Operators such as kea-operator and static-ip-operator **must not** act on a NetworkNamespace until provisioningPhase is Ready. This prevents race conditions where IP allocation starts before the network segment exists.
+
+## IP Allocation Types
+
+### DHCP Allocation
+
+Uses an external DHCP server (typically Kea) for dynamic address assignment:
+
+```yaml
+spec:
+  ipAllocation:
+    type: dhcp
+    provider: kea
+    dhcp:
+      requireClientClasses:
+        - "vitistack"
+```
+
+The kea-operator configures Kea DHCP subnets and pools based on the provisioned network details in status.
+
+### Static Allocation
+
+Uses the static-ip-operator to allocate individual IP addresses from a defined range. Each allocation is tracked as an [IPAllocation](ipallocation.md) resource.
+
+```yaml
+spec:
+  ipAllocation:
+    type: static
+    provider: static-ip-operator
+    static:
+      ipv4CIDR: "10.0.2.0/24"
+      ipv4Gateway: "10.0.2.1"
+      ipv4RangeStart: "10.0.2.10"
+      ipv4RangeEnd: "10.0.2.250"
+      vlanId: 100
+      dns:
+        - "10.0.2.1"
+      ttlSeconds: 3600
+```
+
+## Validation
+
+| Field | Rule | Example |
+|-------|------|---------|
+| spec.datacenterIdentifier | 2-32 chars, ^[A-Za-z0-9_-]+$ | no-west-az1 |
+| spec.supervisorIdentifier | 2-32 chars, ^[A-Za-z0-9_-]+$ | sv-01 |
+| spec.networkProvisioning.provider | Enum: nam, manual | manual |
+| spec.ipAllocation.type | Enum: dhcp, static | static |
+| spec.ipAllocation.provider | 0-32 chars, ^[A-Za-z0-9_-]+$ | kea |
+| spec.networkProvisioning.manual.ipv4CIDR | Valid CIDR pattern | 10.0.2.0/24 |
+| spec.networkProvisioning.manual.vlanId | 0-4094 | 100 |
+| spec.ipAllocation.static.ttlSeconds | Minimum 60, default 3600 | 7200 |
+
+## v1alpha1 Compatibility
+
+The conversion webhook transparently maps between v1alpha1 and v1alpha2:
+
+| v1alpha1 Field | v1alpha2 Equivalent |
+|----------------|---------------------|
+| spec.ipAllocation (with static + inline network) | spec.networkProvisioning.manual + spec.ipAllocation |
+| spec.ipAllocation (DHCP or unset) | spec.networkProvisioning.provider: nam |
+| status.provisioningPhase (string) | status.provisioningPhase (typed enum) |
+| status.ipAllocationStatus | status.ipAllocationSummary |
+| status.ipAllocationStatus.allocatedIPs | Removed — tracked in individual [IPAllocation](ipallocation.md) CRs |
+
+!!! note "Breaking Changes"
+    v1alpha2 removes status.ipAllocationStatus.allocatedIPs (the list of individual allocations). These are now first-class resources tracked as IPAllocation CRDs. The aggregate counts remain in status.ipAllocationSummary.
+
+## Print Columns
+
+```
+NAME           PROVISIONING   DATACENTERIDENTIFIER   PROVISIONINGPHASE   PHASE   STATUS   CREATED
+prod-network   nam            no-west-az1            Ready               Active  OK       2026-05-18T10:00:00Z
+manual-net     manual         no-west-az1            Ready               Active  OK       2026-05-18T11:00:00Z
+```
+
+## Related Resources
+
+- [IPAllocation](ipallocation.md) — Individual IP address allocations within a NetworkNamespace
+- [NetworkConfiguration](../operators/kea-operator.md) — Machine network interface configuration referencing a NetworkNamespace

--- a/docs/reference/crd/proxmoxconfig.md
+++ b/docs/reference/crd/proxmoxconfig.md
@@ -1,0 +1,52 @@
+# ProxmoxConfig
+
+The ProxmoxConfig CRD configures the Proxmox operator integration, defining cluster connection, authentication, defaults, and templates.
+
+## Resource Definition
+
+```yaml
+apiVersion: vitistack.io/v1alpha1
+kind: ProxmoxConfig
+metadata:
+  name: string
+  namespace: string
+spec:
+  # Proxmox Cluster Configuration
+  cluster:
+    nodes: []string             # Proxmox node list
+    endpoint: string            # Cluster API endpoint
+
+  # Authentication Configuration
+  authentication:
+    type: string                # Auth type: pam, pve, ad, ldap
+    realm: string               # Authentication realm
+
+  # Default Configuration
+  defaults:
+    storage: string             # Default storage pool
+    network: string             # Default network bridge
+    osType: string              # Default OS type
+
+  # Resource Limits
+  limits:
+    maxVMsPerNode: int          # Maximum VMs per node
+    maxCPUCores: int            # Maximum CPU cores per VM
+    maxMemory: string           # Maximum memory per VM
+
+  # Template Configuration
+  templates:
+  - id: string                  # Template ID
+    name: string                # Template name
+    osType: string              # Operating system type
+    resources: {}               # Default resources
+
+status:
+  ready: bool                   # Configuration readiness
+  clusterVersion: string        # Proxmox cluster version
+  availableNodes: []string      # Available Proxmox nodes
+```
+
+## Related Resources
+
+- [Machine](machine.md) — VMs managed through Proxmox
+- [MachineProvider](machineprovider.md) — Provider of type proxmox

--- a/docs/reference/crd/vitistack.md
+++ b/docs/reference/crd/vitistack.md
@@ -1,0 +1,65 @@
+# Vitistack
+
+The Vitistack CRD is the primary configuration resource for Viti Stack infrastructure. It defines global settings, provider registrations, and resource quotas for a deployment.
+
+## Resource Definition
+
+```yaml
+apiVersion: vitistack.io/v1alpha1
+kind: Vitistack
+metadata:
+  name: string                     # Infrastructure identifier
+  namespace: string               # Kubernetes namespace
+spec:
+  # Infrastructure Configuration
+  infrastructure:
+    providers:
+    - type: string                 # Provider type: proxmox, talos, kubevirt, kea
+      name: string                # Provider instance name
+      endpoint: string            # Provider API endpoint
+      region: string              # Provider region/zone
+      credentials:
+        secretRef:
+          name: string            # Secret containing credentials
+          namespace: string       # Secret namespace
+
+  # Global Settings
+  settings:
+    defaultStorageClass: string   # Default storage class for volumes
+    defaultNetworkPolicy: string  # Default network policy
+    monitoring:
+      enabled: bool              # Enable monitoring integration
+      namespace: string          # Monitoring namespace
+    logging:
+      enabled: bool              # Enable centralized logging
+      endpoint: string           # Log aggregation endpoint
+
+  # Resource Quotas
+  quotas:
+    machines:
+      total: int                 # Maximum machines across providers
+      perProvider: int           # Maximum machines per provider
+    storage:
+      total: string              # Total storage quota (e.g., "1Ti")
+      perMachine: string         # Maximum storage per machine
+    network:
+      maxNetworks: int           # Maximum networks per namespace
+
+status:
+  phase: string                  # Current phase: Pending, Active, Failed
+  conditions: []Condition        # Status conditions
+  providers: []ProviderStatus    # Provider status information
+  resources:
+    machines: int               # Current machine count
+    networks: int               # Current network count
+    storage: string             # Current storage usage
+```
+
+## Usage
+
+The Vitistack resource acts as the top-level configuration object that ties together all infrastructure components within a namespace. Operators read this resource to discover available providers and apply global policies.
+
+## Related Resources
+
+- [MachineProvider](machineprovider.md) — Provider backends referenced by the infrastructure block
+- [KubernetesProvider](kubernetesprovider.md) — Kubernetes cluster provisioning backends

--- a/docs/reference/operators/index.md
+++ b/docs/reference/operators/index.md
@@ -1,3 +1,65 @@
 # Operators
 
-!!! warning "Work in progress - information to come!"
+Viti Stack is composed of independent operators that each own a specific stage of the infrastructure lifecycle. The operators are designed to be loosely coupled — each watches specific CRDs and gates its work on upstream status fields, forming a pipeline from network provisioning through to running Kubernetes clusters.
+
+## Operator Lifecycle
+
+![Operator Layers](../../images/operator-layers.svg)
+```
+
+## Layers
+
+### Layer 1 — Network Provisioning
+
+Provisions network segments (IP prefixes, VLANs) from an upstream source. Exactly one provisioning operator acts per NetworkNamespace, selected by the spec.networkProvisioning.provider field.
+
+| Operator | Provider | Description |
+|----------|----------|-------------|
+| [nms-operator](vitistack-operator.md) | nam (default) | Allocates network segments from the Network Automation Manager API |
+| [manual-ip-provisioning-operator](manual-ip-provisioning-operator.md) | manual | Copies user-supplied network parameters from spec to status |
+
+**Input:** NetworkNamespace created
+**Output:** NetworkNamespace.status.provisioningPhase = Ready, with ipv4Prefix, vlanId, and gateway populated
+
+### Layer 2 — IP Allocation
+
+Assigns individual IP addresses to machines. Gated on provisioningPhase: Ready — these operators do not act until Layer 1 completes. The allocation method is selected by spec.ipAllocation.type on the NetworkNamespace.
+
+| Operator | Allocation Type | Description |
+|----------|----------------|-------------|
+| [static-ip-operator](ipam-operator.md) | static | Allocates IPs from a defined range, tracked as IPAllocation CRs |
+| [kea-operator](kea-operator.md) | dhcp | Manages DHCP reservations in ISC Kea |
+
+**Input:** NetworkNamespace with provisioningPhase: Ready + NetworkConfiguration with MAC address
+**Output:** IPAllocation with status.phase = Allocated (static) or DHCP lease (dhcp)
+
+### Layer 3 — Machine Provisioning
+
+Creates and manages virtual machines on the underlying hypervisor. Machines reference a MachineProvider that selects which operator handles them.
+
+| Operator | Provider Type | Description |
+|----------|--------------|-------------|
+| [kubevirt-operator](kubevirt-operator.md) | kubevirt | Creates KubeVirt VirtualMachine resources, manages storage and cloud-init |
+| [proxmox-operator](proxmox-operator.md) | proxmox | Creates Proxmox VMs via the Proxmox API |
+
+**Input:** Machine CR with providerRef and NetworkConfiguration with assigned IP
+**Output:** Machine.status.phase = Running
+
+### Layer 4 — Cluster Provisioning
+
+Orchestrates Kubernetes cluster creation by generating Machine manifests and coordinating the bootstrap process.
+
+| Operator | Description |
+|----------|-------------|
+| [talos-operator](talos-operator.md) | Generates Machine CRs from KubernetesCluster spec, manages Talos configuration and cluster bootstrap |
+
+**Input:** KubernetesCluster CR with desired topology
+**Output:** Running Kubernetes cluster with control plane and worker nodes
+
+### Layer 5 — Observability
+
+Cross-cutting monitoring that watches resources across all layers.
+
+| Component | Description |
+|-----------|-------------|
+| kubevirt-status-page | Real-time web UI showing KubeVirt nodes, VMs, and cluster allocation via SSE |

--- a/docs/reference/operators/manual-ip-provisioning-operator.md
+++ b/docs/reference/operators/manual-ip-provisioning-operator.md
@@ -1,0 +1,90 @@
+# Manual IP Provisioning Operator
+
+The `manual-ip-provisioning-operator` handles network provisioning for `NetworkNamespace` resources configured with `networkProvisioning.provider: manual`.
+
+## Purpose
+
+In environments where network segments (IP prefixes, VLANs) are managed externally — for example by a network team, an enterprise IPAM system, or pre-existing infrastructure — the manual provisioning operator allows users to supply this information directly in the `NetworkNamespace` spec rather than relying on an automated provisioning backend.
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant K8s as Kubernetes API
+    participant Op as manual-ip-provisioning-operator
+    participant Downstream as kea-operator / static-ip-operator
+
+    User->>K8s: Create NetworkNamespace (provider: manual)
+    K8s->>Op: Watch event
+    Op->>K8s: Set provisioningPhase: Ready<br/>Populate status fields from spec.manual
+    K8s->>Downstream: NetworkNamespace.status.provisioningPhase = Ready
+    Downstream->>K8s: Begin IP allocation
+```
+
+1. User creates a `NetworkNamespace` with `spec.networkProvisioning.provider: manual`
+2. The operator reads the manual configuration (`ipv4CIDR`, `ipv4Gateway`, `vlanId`)
+3. Populates `status` fields (`ipv4Prefix`, `vlanId`, etc.) from the manual config
+4. Sets `status.provisioningPhase: Ready`
+5. Downstream operators (kea-operator, static-ip-operator) detect `Ready` and begin
+
+## Configuration
+
+The operator requires no special configuration. It watches all `NetworkNamespace` resources and only acts on those with `spec.networkProvisioning.provider: manual`.
+
+## Installation
+
+```bash
+helm install manual-ip-provisioning-operator \
+  oci://ghcr.io/vitistack/helm/manual-ip-provisioning-operator \
+  --namespace vitistack-system
+```
+
+## Example
+
+```yaml
+apiVersion: vitistack.io/v1alpha2
+kind: NetworkNamespace
+metadata:
+  name: lab-network
+  namespace: datacenter-01
+spec:
+  datacenterIdentifier: no-west-az1
+  supervisorIdentifier: lab-01
+  networkProvisioning:
+    provider: manual
+    manual:
+      ipv4CIDR: "192.168.10.0/24"
+      ipv4Gateway: "192.168.10.1"
+      vlanId: 200
+  ipAllocation:
+    type: static
+    provider: static-ip-operator
+    static:
+      ipv4CIDR: "192.168.10.0/24"
+      ipv4Gateway: "192.168.10.1"
+      ipv4RangeStart: "192.168.10.10"
+      ipv4RangeEnd: "192.168.10.200"
+      vlanId: 200
+      dns:
+        - "192.168.10.1"
+```
+
+After the operator reconciles:
+
+```yaml
+status:
+  provisioningPhase: Ready
+  ipv4Prefix: "192.168.10.0/24"
+  vlanId: 200
+  datacenterIdentifier: no-west-az1
+  supervisorIdentifier: lab-01
+  phase: Active
+  status: OK
+```
+
+## Related
+
+- [NetworkNamespace CRD](../crd/networknamespace.md)
+- [IPAllocation CRD](../crd/ipallocation.md)
+- [Static IP Operator](../operators/ipam-operator.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -115,8 +115,21 @@ nav:
           - reference/operators/physical-operator.md
           - reference/operators/kea-operator.md
           - reference/operators/ipam-operator.md
+          - reference/operators/manual-ip-provisioning-operator.md
       - CRDs:
           - reference/crd/index.md
+          - reference/crd/vitistack.md
+          - reference/crd/machine.md
+          - reference/crd/machineclass.md
+          - reference/crd/networkconfiguration.md
+          - reference/crd/networknamespace.md
+          - reference/crd/ipallocation.md
+          - reference/crd/machineprovider.md
+          - reference/crd/kubernetesprovider.md
+          - reference/crd/kubernetescluster.md
+          - reference/crd/etcdbackup.md
+          - reference/crd/kubevirtconfig.md
+          - reference/crd/proxmoxconfig.md
       - API:
           - reference/api/index.md
           - reference/api/ipam-api.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -1582,7 +1582,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1467305.tgz",
       "integrity": "sha512-LxwMLqBoPPGpMdRL4NkLFRNy3QLp6Uqa7GNp1v6JaBheop2QrB9Q7q0A/q/CYYP9sBfZdHOyszVx4gc9zyk7ow==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/dot-prop": {
       "version": "5.3.0",
@@ -4117,6 +4118,7 @@
         }
       ],
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@bazel/runfiles": "^6.5.0",
         "jszip": "^3.10.1",


### PR DESCRIPTION
- Introduced KubernetesCluster CRD for managing Kubernetes clusters with provider references and configuration.
- Added KubernetesProvider CRD to configure cluster provisioning backends, including templates and add-ons.
- Created KubevirtConfig CRD for KubeVirt operator integration, defining feature gates and resource defaults.
- Defined Machine CRD for virtual machines, specifying hardware resources, networking, and OS configuration.
- Implemented MachineClass CRD for reusable machine size templates at the cluster scope.
- Established MachineProvider CRD for configuring machine provisioning backends with connection details and capacity.
- Developed NetworkConfiguration CRD for network interface configuration and VLAN settings for machines.
- Introduced NetworkNamespace CRD for defining network isolation boundaries with IP prefix and VLAN provisioning.
- Added ProxmoxConfig CRD for configuring Proxmox operator integration with cluster connection and templates.
- Created Vitistack CRD as the primary configuration resource for Viti Stack infrastructure, defining global settings and resource quotas.

Update documentation to include new CRDs and operator lifecycle details

- Updated operators index to reflect new operator layers and their responsibilities.
- Added manual IP provisioning operator documentation for handling manual network provisioning.
- Enhanced mkdocs.yml to include new CRD and operator documentation in the navigation structure.